### PR TITLE
feat(types): liberally derive std traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Implemented common `std` library traits for all public types (#5)
+
 ### Changed
 
 - Made the fields of `knus::ast::Integer` and `knus::ast::Decimal` public (#1)

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -27,7 +27,7 @@ pub type SpannedName<S> = Spanned<Box<str>, S>;
 pub type SpannedNode<S> = Spanned<Node<S>, S>;
 
 /// Single node of the KDL document
-#[derive(Debug, Clone)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct Node<S> {
     /// A type name if specified in parenthesis
@@ -48,7 +48,7 @@ pub struct Node<S> {
 }
 
 /// KDL document root
-#[derive(Debug, Clone)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct Document<S> {
     /// Nodes of the document
@@ -57,7 +57,7 @@ pub struct Document<S> {
 }
 
 /// Possible integer radices described by the KDL specification
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "minicbor", cbor(index_only))]
 pub enum Radix {
@@ -68,6 +68,7 @@ pub enum Radix {
     #[cfg_attr(feature = "minicbor", n(8))]
     Oct,
     /// Decimal (Base 10)
+    #[default]
     #[cfg_attr(feature = "minicbor", n(10))]
     Dec,
     /// Hexadecimal (Base 16)
@@ -76,7 +77,7 @@ pub enum Radix {
 }
 
 /// Potentially unlimited size integer value
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct Integer(
     #[cfg_attr(feature = "minicbor", n(0))] pub Radix,
@@ -84,13 +85,13 @@ pub struct Integer(
 );
 
 /// Potentially unlimited precision decimal value
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 #[cfg_attr(feature = "minicbor", cbor(transparent))]
 pub struct Decimal(#[cfg_attr(feature = "minicbor", n(0))] pub Box<str>);
 
 /// Possibly typed KDL scalar value
-#[derive(Debug, Clone)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct Value<S> {
     /// A type name if specified in parenthesis
@@ -102,10 +103,10 @@ pub struct Value<S> {
 }
 
 /// Type identifier
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct TypeName(TypeNameInner);
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 enum TypeNameInner {
     Builtin(BuiltinType),
     Custom(Box<str>),
@@ -114,8 +115,10 @@ enum TypeNameInner {
 /// Known type identifiers described by the KDL specification — there are more
 /// types defined in the specification than this enum captures, so this enum is
 /// `non_exhaustive` for now.
+// MISSING: It doesn't really make sense to pick a "default" type here, so the
+// `Default` implementation is intentionally missing
 #[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub enum BuiltinType {
     /// `u8`: 8-bit unsigned integer type
     U8,
@@ -146,10 +149,11 @@ pub enum BuiltinType {
 }
 
 /// Scalar KDL value
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub enum Literal {
     /// Null value
+    #[default]
     #[cfg_attr(feature = "minicbor", n(0))]
     Null,
     /// Boolean value

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -14,7 +14,7 @@ use crate::traits::{Decode, ErrorSpan};
 ///
 /// 1. To emit error and proceed (so multiple errors presented to user)
 /// 2. To store and retrieve data in decoders of nodes, scalars and spans
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Context<S: ErrorSpan> {
     errors: Vec<DecodeError<S>>,
     extensions: HashMap<TypeId, Box<dyn Any>>,
@@ -23,7 +23,7 @@ pub struct Context<S: ErrorSpan> {
 /// Scalar value kind
 ///
 /// Currently used only for error reporting
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub enum Kind {
     /// An unquoted integer value, signed or unsigned. Having no decimal point.
     /// Can be of virtually unlimited length. Can be expressed in binary, octal,
@@ -38,6 +38,7 @@ pub enum Kind {
     /// A boolean value of `true` or `false`
     Bool,
     /// The null value (usually corresponds to `None` in Rust)
+    #[default]
     Null,
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -526,7 +526,10 @@ impl<S: ErrorSpan> DecodeError<S> {
 }
 
 /// Wrapper around expected type that is used in [`DecodeError::TypeName`].
-#[derive(Debug)]
+// MISSING: The `Default` implementation is missing, since there is no clear
+// default here — really, this should be an enum, since `types` only makes sense
+// when `no_type` is `false`. This needs a refactor at some point!
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct ExpectedType {
     types: Vec<TypeName>,
     no_type: bool,
@@ -585,7 +588,7 @@ impl fmt::Display for ExpectedType {
 /// Declares kind of value expected for the scalar value
 ///
 /// Use [`Kind`](crate::decode::Kind) and `.into()` to create this value.
-#[derive(Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 pub struct ExpectedKind(Kind);
 
 impl From<Kind> for ExpectedKind {

--- a/src/span.rs
+++ b/src/span.rs
@@ -21,7 +21,7 @@ use crate::traits;
 pub use miette::SourceSpan as ErrorSpan;
 
 /// Wraps the structure to keep source code span, but also dereference to T
-#[derive(Clone, Copy, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct Spanned<T, S> {
     #[cfg_attr(feature = "minicbor", n(0))]
@@ -31,7 +31,7 @@ pub struct Spanned<T, S> {
 }
 
 /// Normal byte offset span
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct Span(
     #[cfg_attr(feature = "minicbor", n(0))] pub usize,
@@ -40,7 +40,7 @@ pub struct Span(
 
 /// Line and column position of the datum in the source code
 // TODO(tailhook) optimize Eq to check only offset
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct LinePos {
     /// Zero-based byte offset
@@ -55,7 +55,7 @@ pub struct LinePos {
 }
 
 /// Span with line and column number
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct LineSpan(
     #[cfg_attr(feature = "minicbor", n(0))] pub LinePos,

--- a/src/span.rs
+++ b/src/span.rs
@@ -21,7 +21,7 @@ use crate::traits;
 pub use miette::SourceSpan as ErrorSpan;
 
 /// Wraps the structure to keep source code span, but also dereference to T
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct Spanned<T, S> {
     #[cfg_attr(feature = "minicbor", n(0))]
@@ -31,7 +31,7 @@ pub struct Spanned<T, S> {
 }
 
 /// Normal byte offset span
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct Span(
     #[cfg_attr(feature = "minicbor", n(0))] pub usize,
@@ -40,7 +40,7 @@ pub struct Span(
 
 /// Line and column position of the datum in the source code
 // TODO(tailhook) optimize Eq to check only offset
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct LinePos {
     /// Zero-based byte offset
@@ -55,7 +55,7 @@ pub struct LinePos {
 }
 
 /// Span with line and column number
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct LineSpan(
     #[cfg_attr(feature = "minicbor", n(0))] pub LinePos,


### PR DESCRIPTION
Brings things in line with https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits