### PR TITLE
added support for "name" attribute for enum variants

### DIFF
--- a/derive/derive_decode.md
+++ b/derive/derive_decode.md
@@ -733,7 +733,24 @@ The following variants supported:
    expected in such node
 5. Variant with `skip`, cannot be deserialized and can be in any form
 
-Enum variant names are matches against node names converted into `kebab-case`.
+Enum variant names are matches against node names converted into `kebab-case` by default.
+However a `name` attribute can be specified, like so:
+```rust
+# #[derive(knus::Decode)] struct PrintString {}
+#[derive(knus::Decode)]
+enum Action {
+    #[knus(name="Create")]
+    Create(#[knus(argument)] String),
+
+    #[knus(name="PrintString")]
+    PrintString(PrintString),
+}
+```
+```kdl
+Create "xxx"
+PrintString "yyy" line=2
+```
+
 
 # Container Attributes
 

--- a/derive/derive_decode.md
+++ b/derive/derive_decode.md
@@ -329,6 +329,20 @@ Note: we use same node type for `plugin` and `datum` nodes. Generally nodes do
 not match on the actual node names, it's the job of the parent node to sort
 out their children into the right buckets. Also see [Enums](#enums).
 
+Also note that you can specify name for the child node too `child(name="something")`, like so:
+```rust
+#[derive(knus::Decode)]
+struct Version {
+    #[knus(argument)]
+    number: u32
+}
+#[derive(knus::Decode)]
+struct MyNode {
+    #[knus(child(name="ver"))]
+    version: Version,
+}
+```
+
 ## Boolean Child Fields
 
 Sometimes you want to track just the presence of the child in the node.

--- a/derive/derive_decode.md
+++ b/derive/derive_decode.md
@@ -734,7 +734,7 @@ The following variants supported:
 5. Variant with `skip`, cannot be deserialized and can be in any form
 
 Enum variant names are matches against node names converted into `kebab-case` by default.
-However a `name` attribute can be specified, like so:
+However, a `name` attribute can be specified, like so:
 ```rust
 # #[derive(knus::Decode)] struct PrintString {}
 #[derive(knus::Decode)]

--- a/derive/tests/normal.rs
+++ b/derive/tests/normal.rs
@@ -119,7 +119,10 @@ struct FilteredChildren {
 #[derive(knus_derive::Decode, Debug, PartialEq)]
 enum Variant {
     Arg1(Arg1),
+
+    #[knus(name = "prop1_renamed")]
     Prop1(Prop1),
+
     #[knus(skip)]
     #[allow(dead_code)]
     Var3(u32),
@@ -774,14 +777,14 @@ fn parse_enum() {
         })
     );
     assert_eq!(
-        parse::<Variant>(r#"prop1 label="hello""#),
+        parse::<Variant>(r#"prop1_renamed label="hello""#),
         Variant::Prop1(Prop1 {
             label: "hello".into()
         })
     );
     assert_eq!(
         parse_err::<Variant>(r#"something"#),
-        "expected one of `arg1`, `prop1`"
+        "expected one of `arg1`, `prop1_renamed`"
     );
 }
 

--- a/derive/tests/normal.rs
+++ b/derive/tests/normal.rs
@@ -178,7 +178,7 @@ struct UnwrapChildren {
 
 #[derive(knus_derive::Decode, Debug, PartialEq)]
 struct Parse {
-    #[knus(child, unwrap(argument, str))]
+    #[knus(child(name = "listen-addr"), unwrap(argument, str))]
     listen: std::net::SocketAddr,
 }
 
@@ -791,12 +791,12 @@ fn parse_enum() {
 #[test]
 fn parse_str() {
     assert_eq!(
-        parse_doc::<Parse>(r#"listen "127.0.0.1:8080""#),
+        parse_doc::<Parse>(r#"listen-addr "127.0.0.1:8080""#),
         Parse {
             listen: "127.0.0.1:8080".parse().unwrap()
         }
     );
-    assert!(parse_doc_err::<Parse>(r#"listen "2/3""#).contains("invalid"));
+    assert!(parse_doc_err::<Parse>(r#"listen-addr "2/3""#).contains("invalid"));
 
     assert_eq!(
         parse::<ParseOpt>(r#"server listen="127.0.0.1:8080""#),


### PR DESCRIPTION
Upd: added support for `name="something"` for child node too

fixes https://github.com/TheLostLambda/knus/issues/12

done:
- reused 'name' attribute
  - although now it can be top level, instead being an inner part of `attribute` or `argument`
  - like so  `#[knus(name="PrintString")]`
  - it doesn't seem great to not reuse the established pattern with other renames (like inside `child`), but seems clean enough (`skip` is already top level and only applicable for enum variants)
- used `name` value if present for code generation
- changed test in `derive/tests/normal.rs`
- added changes to `derive_decode.md`, but not inside `README.md` for consistency
- added support for `child(name="something")` too

---
so now this works as expected:

```rust
enum Action {
    #[knus(name="Create")]
    Create(#[knus(argument)] String),

    #[knus(name="PrintString")]
    PrintString(PrintString),
}
```
```kdl
Create "xxx"
PrintString "yyy" line=2
```

---
and this:
```rust
#[derive(knus::Decode)]
struct Version {
    #[knus(argument)]
    number: u32
}
#[derive(knus::Decode)]
struct MyNode {
    #[knus(child(name="ver"))]
    version: Version,
}
```
```kdl
ver 1
```