### PR TITLE
feat: add attribute `#[transparent]` to single-variant enums

### DIFF
--- a/derive/derive_decode.md
+++ b/derive/derive_decode.md
@@ -725,7 +725,11 @@ enum Action {
 
 The following variants supported:
 1. Single element tuple struct without arguments (`PrintString` in example),
-   which forwards node parsing to the inner element.
+   which adds a node called `print-string` and forwards rest of the parsing after to the inner element.
+
+   There is an additional attribute `#[knus(transparent)]` which can be applied to these types of variants.
+   It will fully forward the parsing to the inner element, without requiring a prefix such as `print-string`.
+
 2. Normal `argument`, `arguments`, `properties`, `children` fields (`Create`
    example)
 3. Property fields with names `property(name="xxx")`

--- a/derive/src/definition.rs
+++ b/derive/src/definition.rs
@@ -1,9 +1,14 @@
 use std::fmt;
 use std::mem;
 
+use proc_macro_error2::abort;
 use proc_macro_error2::emit_error;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
+use syn::GenericArgument;
+use syn::PathArguments;
+use syn::Type;
+use syn::TypePath;
 use syn::ext::IdentExt;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
@@ -21,7 +26,15 @@ pub enum Definition {
 
 pub enum VariantKind {
     Unit,
-    Nested { option: bool },
+    Nested {
+        /// None: The type is not optional
+        /// Some: Type is optional. Contains value inside the Option<...>
+        option: Option<Type>,
+        /// Delegate the entire parsing to the inner type
+        transparent: bool,
+        /// Type contained within
+        inner_ty: TypePath,
+    },
     Tuple(Struct),
     Named,
 }
@@ -70,6 +83,8 @@ pub enum Attr {
     Unwrap(FieldAttrs),
     Default(Option<syn::Expr>),
     SpanType(syn::Type),
+    /// When applied to newtype enum variants, delegate all parsing to the inner type
+    Transparent,
 }
 
 #[derive(Debug, Clone)]
@@ -83,6 +98,8 @@ pub struct FieldAttrs {
 #[derive(Debug, Clone)]
 pub struct VariantAttrs {
     pub skip: bool,
+    /// Delegate all parsing to the inner type (on newtype enum variants)
+    pub transparent: bool,
 }
 
 #[derive(Clone)]
@@ -166,7 +183,9 @@ pub enum ExtraKind {
 pub struct ExtraField {
     pub field: Field,
     pub kind: ExtraKind,
-    pub option: bool,
+    /// If the type is not Option, is None
+    /// If the type is Option, is Some(inner type)
+    pub option: Option<Type>,
 }
 
 #[derive(Clone)]
@@ -246,17 +265,31 @@ fn err_pair(s1: &Field, s2: &Field, t1: &str, t2: &str) -> syn::Error {
     err
 }
 
-fn is_option(ty: &syn::Type) -> bool {
-    matches!(ty,
-        syn::Type::Path(syn::TypePath {
-            qself: None,
-            path: syn::Path {
-                leading_colon: None,
-                segments,
-            },
-        })
-        if segments.len() == 1 && segments[0].ident == "Option"
-    )
+/// # Returns
+///
+/// If the value is not an option, return `None`
+/// If the value is an option, return `Some(inner type)`
+fn is_option(ty: &syn::Type) -> Option<Type> {
+    if let syn::Type::Path(syn::TypePath {
+        qself: None,
+        path: syn::Path {
+            leading_colon: None,
+            segments,
+        },
+    }) = ty
+    {
+        if let Some(segment) = segments.first() {
+            if segment.ident == "Option" {
+                if let PathArguments::AngleBracketed(args) = &segment.arguments {
+                    if let Some(GenericArgument::Type(ty)) = args.args.first() {
+                        return Some(ty.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    None
 }
 
 fn is_bool(ty: &syn::Type) -> bool {
@@ -298,6 +331,7 @@ impl Enum {
             let kind = match var.fields {
                 syn::Fields::Named(_) => VariantKind::Named,
                 syn::Fields::Unnamed(u) => {
+                    let first_field = u.unnamed.first().cloned();
                     let tup = Struct::new(
                         var.ident.clone(),
                         trait_props.clone(),
@@ -308,11 +342,17 @@ impl Enum {
                         && tup.extra_fields.len() == 1
                         && matches!(tup.extra_fields[0].kind, ExtraKind::Auto)
                     {
+                        let first_field = first_field.expect("len == 1");
+                        let Type::Path(ty) = first_field.ty else {
+                            abort!(first_field.span(), "type must be a path");
+                        };
                         // Single tuple variant without any defition means
                         // the first field inside is meant to be full node
                         // parser.
                         VariantKind::Nested {
-                            option: tup.extra_fields[0].option,
+                            option: tup.extra_fields[0].option.clone(),
+                            transparent: attrs.transparent,
+                            inner_ty: ty,
                         }
                     } else {
                         VariantKind::Tuple(tup)
@@ -371,7 +411,7 @@ impl StructBuilder {
     pub fn add_field(
         &mut self,
         field: Field,
-        is_option: bool,
+        is_option: Option<Type>,
         is_bool: bool,
         attrs: &FieldAttrs,
     ) -> syn::Result<&mut Self> {
@@ -387,14 +427,16 @@ impl StructBuilder {
                 }
                 self.arguments.push(Arg {
                     field,
-                    kind: ArgKind::Value { option: is_option },
+                    kind: ArgKind::Value {
+                        option: is_option.is_some(),
+                    },
                     decode: attrs
                         .decode
                         .as_ref()
                         .map(|(v, _)| v.clone())
                         .unwrap_or(DecodeMode::Normal),
                     default: attrs.default.clone(),
-                    option: is_option,
+                    option: is_option.is_some(),
                 });
             }
             Some(FieldMode::Arguments) => {
@@ -440,7 +482,7 @@ impl StructBuilder {
                 self.properties.push(Prop {
                     field,
                     name,
-                    option: is_option,
+                    option: is_option.is_some(),
                     decode: attrs
                         .decode
                         .as_ref()
@@ -493,7 +535,7 @@ impl StructBuilder {
                 self.children.push(Child {
                     name,
                     field,
-                    option: is_option,
+                    option: is_option.is_some(),
                     mode: if attrs.unwrap.is_none() && is_bool {
                         ChildMode::Bool
                     } else {
@@ -516,7 +558,7 @@ impl StructBuilder {
                 self.children.push(Child {
                     name: name.clone(),
                     field,
-                    option: is_option,
+                    option: is_option.is_some(),
                     mode: ChildMode::Multi,
                     unwrap: attrs.unwrap.clone(),
                     default: attrs.default.clone(),
@@ -538,7 +580,7 @@ impl StructBuilder {
                 });
             }
             Some(FieldMode::Flatten(flatten)) => {
-                if is_option {
+                if is_option.is_some() {
                     return Err(syn::Error::new(
                         field.span,
                         "optional flatten fields are not supported yet",
@@ -558,7 +600,7 @@ impl StructBuilder {
                     self.properties.push(Prop {
                         field: field.clone(),
                         name: "".into(), // irrelevant
-                        option: is_option,
+                        option: is_option.is_some(),
                         decode: DecodeMode::Normal,
                         flatten: true,
                         default: None,
@@ -577,7 +619,7 @@ impl StructBuilder {
                     self.children.push(Child {
                         name: "".into(), // unused
                         field: field.clone(),
-                        option: is_option,
+                        option: is_option.is_some(),
                         mode: ChildMode::Flatten,
                         unwrap: None,
                         default: None,
@@ -596,7 +638,7 @@ impl StructBuilder {
                 attrs.no_decode("type_name");
                 self.type_names.push(TypeNameField {
                     field,
-                    option: is_option,
+                    option: is_option.is_some(),
                 });
             }
             None => {
@@ -771,7 +813,10 @@ impl FieldAttrs {
 
 impl VariantAttrs {
     fn new() -> VariantAttrs {
-        VariantAttrs { skip: false }
+        VariantAttrs {
+            skip: false,
+            transparent: false,
+        }
     }
     fn update(&mut self, attrs: impl IntoIterator<Item = (Attr, Span)>) {
         use Attr::*;
@@ -779,6 +824,7 @@ impl VariantAttrs {
         for (attr, span) in attrs {
             match attr {
                 Skip => self.skip = true,
+                Transparent => self.transparent = true,
                 _ => emit_error!(span, "not supported on enum variants"),
             }
         }
@@ -809,7 +855,10 @@ impl Attr {
     }
     fn _parse(input: ParseStream) -> syn::Result<Self> {
         let lookahead = input.lookahead1();
-        if lookahead.peek(kw::argument) {
+        if lookahead.peek(kw::transparent) {
+            let _kw: kw::transparent = input.parse()?;
+            Ok(Attr::Transparent)
+        } else if lookahead.peek(kw::argument) {
             let _kw: kw::argument = input.parse()?;
             Ok(Attr::FieldMode(FieldMode::Argument))
         } else if lookahead.peek(kw::arguments) {

--- a/derive/src/definition.rs
+++ b/derive/src/definition.rs
@@ -24,6 +24,7 @@ pub enum Definition {
     Enum(Enum),
 }
 
+#[allow(clippy::large_enum_variant)]
 pub enum VariantKind {
     Unit,
     Nested {

--- a/derive/src/definition.rs
+++ b/derive/src/definition.rs
@@ -343,9 +343,18 @@ impl Enum {
                         && matches!(tup.extra_fields[0].kind, ExtraKind::Auto)
                     {
                         let first_field = first_field.expect("len == 1");
-                        let Type::Path(ty) = first_field.ty else {
-                            abort!(first_field.span(), "type must be a path");
+                        let span = first_field.span();
+                        let ty = match first_field.ty {
+                            Type::Path(ty) => ty,
+                            Type::Group(ty) => {
+                                let Type::Path(ty) = *ty.elem else {
+                                    abort!(span, "type must be a path");
+                                };
+                                ty
+                            }
+                            _ => abort!(span, "type must be a path"),
                         };
+
                         // Single tuple variant without any defition means
                         // the first field inside is meant to be full node
                         // parser.

--- a/derive/src/kw.rs
+++ b/derive/src/kw.rs
@@ -15,3 +15,4 @@ syn::custom_keyword!(span_type);
 syn::custom_keyword!(str);
 syn::custom_keyword!(type_name);
 syn::custom_keyword!(unwrap);
+syn::custom_keyword!(transparent);

--- a/derive/src/node.rs
+++ b/derive/src/node.rs
@@ -573,7 +573,7 @@ fn unwrap_fn(
         parent.object.trait_props.clone(),
         parent.object.generics.clone(),
     );
-    bld.add_field(Field::new_named(name), false, false, attrs)?;
+    bld.add_field(Field::new_named(name), None, false, attrs)?;
     let object = bld.build();
     let common = Common {
         object: &object,

--- a/derive/src/variants.rs
+++ b/derive/src/variants.rs
@@ -59,6 +59,7 @@ pub fn emit_enum(e: &Enum) -> syn::Result<TokenStream> {
 fn decode(e: &Common, node: &syn::Ident) -> syn::Result<TokenStream> {
     let ctx = e.ctx;
     let mut branches = Vec::with_capacity(e.object.variants.len());
+    let mut transparent_variants = Vec::with_capacity(e.object.variants.len());
     let enum_name = &e.object.ident;
     for var in &e.object.variants {
         let name = &var.name;
@@ -94,13 +95,50 @@ fn decode(e: &Common, node: &syn::Ident) -> syn::Result<TokenStream> {
                     }
                 });
             }
-            VariantKind::Nested { option: false } => {
+            VariantKind::Nested {
+                option: None,
+                transparent: false,
+                ..
+            } => {
                 branches.push(quote! {
                     #name => ::knus::Decode::decode_node(#node, #ctx)
                         .map(#enum_name::#variant_name),
                 });
             }
-            VariantKind::Nested { option: true } => {
+            VariantKind::Nested {
+                option: None,
+                transparent: true,
+                inner_ty,
+            } => {
+                // Use the inner type to decode the input, then wrap it inside of the variant
+                transparent_variants.push(quote! {
+                   #inner_ty::decode_node(#node, #ctx).map(#enum_name::#variant_name)
+                });
+            }
+            VariantKind::Nested {
+                option: Some(inner_ty),
+                transparent: true,
+                ..
+            } => {
+                // Use the inner type (inside the option) to decode the input,
+                transparent_variants.push(quote! {
+                    {
+                        if #node.arguments.len() > 0 ||
+                            #node.properties.len() > 0 ||
+                            #node.children.is_some()
+                        {
+                            #inner_ty::decode_node(#node, #ctx).map(Some).map(#enum_name::#variant_name)
+                        } else {
+                            Ok(#enum_name::#variant_name(None))
+                        }
+                    }
+                });
+            }
+            VariantKind::Nested {
+                option: Some(_),
+                transparent: false,
+                ..
+            } => {
                 branches.push(quote! {
                     #name => {
                         if #node.arguments.len() > 0 ||
@@ -155,11 +193,17 @@ fn decode(e: &Common, node: &syn::Ident) -> syn::Result<TokenStream> {
         )
     };
     Ok(quote! {
-        match &**#node.node_name {
-            #(#branches)*
-            name_str => {
-                Err(::knus::errors::DecodeError::conversion(
-                        &#node.node_name, #err))
+        #(
+            if let Ok(parsed) = #transparent_variants {
+                Ok(parsed)
+            } else
+        )* {
+            match &**#node.node_name {
+                #(#branches)*
+                name_str => {
+                    Err(::knus::errors::DecodeError::conversion(
+                            &#node.node_name, #err))
+                }
             }
         }
     })

--- a/derive/tests/transparent.rs
+++ b/derive/tests/transparent.rs
@@ -1,0 +1,103 @@
+macro_rules! make_wrappers {
+    ($($Wrapper:ident($Left:ident, $Right:ident)),* $(,)?) => {
+        $(
+            #[derive(knus::Decode, Debug, Eq, PartialEq)]
+            pub struct $Left {
+                #[knus(argument)]
+                pub left: u32,
+                #[knus(argument)]
+                pub right: u32,
+            }
+
+            #[derive(knus::Decode, Debug, Eq, PartialEq)]
+            pub struct $Right {
+                #[knus(argument)]
+                pub left: u32,
+                #[knus(argument)]
+                pub right: u32,
+            }
+
+            #[derive(knus::Decode, Debug, Eq, PartialEq)]
+            pub enum $Wrapper {
+                $Left($Left),
+                $Right($Right)
+            }
+        )*
+    }
+}
+
+mod letters {
+    make_wrappers! {
+        Letter1(A, B),
+        Letter2(C, D),
+        Letter3(E, F),
+        Letter4(G, H),
+        Letter5(I, J)
+    }
+}
+
+use letters::*;
+
+#[derive(knus::Decode, Debug, Eq, PartialEq)]
+enum Letter {
+    /// Reference inner using path
+    #[knus(transparent)]
+    LetterA(letters::Letter1),
+    /// Uses the same name as the inner variant
+    #[knus(transparent)]
+    Letter2(Letter2),
+    /// Inner variant is `Option<...>`
+    #[knus(transparent)]
+    Optional(Option<Letter3>),
+    /// Inner variant is `Option<...>`
+    /// And reference with path
+    #[knus(transparent)]
+    OptionalWithPath(Option<letters::Letter4>),
+}
+
+#[test]
+fn test() {
+    use Letter as L;
+
+    assert_eq!(
+        knus::parse::<Vec<Letter>>(
+            "test.kdl",
+            "
+            a 1 2
+            b 3 4
+
+            c 5 6
+            d 7 8
+
+            e 9 10
+            f 11 12
+
+            g 13 14
+            h 10 20
+        ",
+        )
+        .unwrap(),
+        vec![
+            L::LetterA(Letter1::A(A { left: 1, right: 2 })),
+            L::LetterA(Letter1::B(B { left: 3, right: 4 })),
+            //
+            L::Letter2(Letter2::C(C { left: 5, right: 6 })),
+            L::Letter2(Letter2::D(D { left: 7, right: 8 })),
+            //
+            L::Optional(Some(Letter3::E(E { left: 9, right: 10 }))),
+            L::Optional(Some(Letter3::F(F {
+                left: 11,
+                right: 12,
+            }))),
+            //
+            L::OptionalWithPath(Some(Letter4::G(G {
+                left: 13,
+                right: 14,
+            }))),
+            L::OptionalWithPath(Some(Letter4::H(H {
+                left: 10,
+                right: 20,
+            }))),
+        ]
+    );
+}


### PR DESCRIPTION
Closes #24 

The problem I described in the linked issue can be solved by adding the new attribute:

```diff
/// A list of keybindings which exist in the app
#[derive(knus::Decode, Debug, Clone)]
pub enum KeymappableCommand {
+   #[knus(transparent)]
    ImageUpload(ImageCommand),
    // ... there are a lot more ...
}
```