### PR TITLE
Implement `decode_with` for scalar fields

### DIFF
--- a/derive/derive_decode.md
+++ b/derive/derive_decode.md
@@ -202,6 +202,7 @@ There are additional attributes that define how scalar values are parsed:
 * `bytes` -- decodes binary strings, either by decoding `base64` if the `(base64)` type is specified in the source or by encoding string into `utf-8` if no type is specified. This is required since
 * `default` -- described in [Common Attrbites](#common-attributes) section
   since it applies to nodes (non-scalar values) too.
+* `decode_with` -- similar to `str`, but rather than [`FromStr`](std::str::FromStr), takes a path to a custom decode function
 
 All of them work on [properties](#properties) and [arguments](#arguments).
 
@@ -257,6 +258,24 @@ example
 [`bstr::BString`](https://docs.rs/bstr/latest/bstr/struct.BString.html) and
 [`bytes::Bytes`](https://docs.rs/bytes/latest/bytes/struct.Bytes.html) work too.
 
+
+## Custom `decode_with`
+
+`decode_with` is somewhat analogous to serde's `deserialize_with` attribute:
+
+```rust
+fn decode_duration_seconds(s: &str) -> Result<std::time::Duration, std::num::ParseIntError>
+{
+    s.parse::<u64>()
+        .map(std::time::Duration::from_secs)
+}
+
+#[derive(knus_derive::Decode)]
+struct DecodeWith {
+    #[knus(child, unwrap(argument, decode_with = decode_duration_seconds))]
+    duration: std::time::Duration,
+}
+```
 
 # Children
 

--- a/derive/src/definition.rs
+++ b/derive/src/definition.rs
@@ -60,6 +60,7 @@ pub enum DecodeMode {
     Normal,
     Str,
     Bytes,
+    With(syn::ExprPath)
 }
 
 #[derive(Debug)]
@@ -872,6 +873,11 @@ impl Attr {
         } else if lookahead.peek(kw::bytes) {
             let _kw: kw::bytes = input.parse()?;
             Ok(Attr::DecodeMode(DecodeMode::Bytes))
+        } else if lookahead.peek(kw::decode_with) {
+            let _kw: kw::decode_with = input.parse()?;
+            let _eq: syn::Token![=] = input.parse()?;
+            let path: syn::ExprPath = input.parse()?;
+            Ok(Attr::DecodeMode(DecodeMode::With(path)))
         } else if lookahead.peek(kw::flatten) {
             let _kw: kw::flatten = input.parse()?;
             let parens;
@@ -987,10 +993,10 @@ impl fmt::Display for DecodeMode {
         use DecodeMode::*;
 
         match self {
-            Normal => "normal",
-            Str => "str",
-            Bytes => "bytes",
+            Normal => "normal".fmt(f),
+            Str => "str".fmt(f),
+            Bytes => "bytes".fmt(f),
+            With(path) => write!(f, "with \"{:?}\"", path)
         }
-        .fmt(f)
     }
 }

--- a/derive/src/kw.rs
+++ b/derive/src/kw.rs
@@ -15,3 +15,4 @@ syn::custom_keyword!(span_type);
 syn::custom_keyword!(str);
 syn::custom_keyword!(type_name);
 syn::custom_keyword!(unwrap);
+syn::custom_keyword!(decode_with);


### PR DESCRIPTION
`decode_with` is roughly analogous to serde's `deserialize_with`:

```rust
fn decode_duration_seconds(s: &str) -> Result<std::time::Duration, std::num::ParseIntError>
{
    s.parse::<u64>()
        .map(std::time::Duration::from_secs)
}

#[derive(knus_derive::Decode)]
struct DecodeWith {
    #[knus(child, unwrap(argument, decode_with = decode_duration_seconds))]
    duration: std::time::Duration,
}
```

this is particularly useful when deserialising types from other crates which do not already implement `FromStr`. otherwise it's just a mess of newtypes.

i've implemented the functionality, added tests (basically copied the `str` parse tests), and some rudimentary docs. happy to refine the PR as needed!