### PR TITLE
Merge `main` into `kdl-v2` and update tests for the new syntax

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,12 +1,2 @@
-[target.aarch64-apple-darwin]
+[target.'cfg(any(target_os = "windows", target_os = "macos"))']
 linker = "rust-lld"
-# NOTE: `rustdoc` doesn't currently respect the `linker` setting — keep an eye
-# on this issue: https://github.com/rust-lang/rust/issues/125657
-rustdocflags = ["-Clink-arg=-fuse-ld=lld"]
-
-# NOTE: Also annoyingly, `target.<cfg>` doesn't let you set `rustdocflags`, so
-# something like `[target.'cfg(target_os = "macos")']` doesn't work here and
-# this repetition is needed...
-[target.x86_64-apple-darwin]
-linker = "rust-lld"
-rustdocflags = ["-Clink-arg=-fuse-ld=lld"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,5 +26,5 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 The beginning of time — this version is identical to [`knuffel` v3.2.0](https://crates.io/crates/knuffel/3.2.0).
 
 [unreleased]: https://github.com/TheLostLambda/knus/compare/v3.3.0...HEAD
-[3.3.0]: https://github.com/TheLostLambda/knus/releases/tag/v3.2.0...v3.3.0
+[3.3.0]: https://github.com/TheLostLambda/knus/compare/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/TheLostLambda/knus/releases/tag/v3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-## [3.3.0] - 2025-04-30
+## [3.3.1] - 2025-04-30
 
 ### Added
 
@@ -25,6 +25,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 The beginning of time — this version is identical to [`knuffel` v3.2.0](https://crates.io/crates/knuffel/3.2.0).
 
-[unreleased]: https://github.com/TheLostLambda/knus/compare/v3.3.0...HEAD
-[3.3.0]: https://github.com/TheLostLambda/knus/compare/v3.2.0...v3.3.0
+[unreleased]: https://github.com/TheLostLambda/knus/compare/v3.3.1...HEAD
+[3.3.1]: https://github.com/TheLostLambda/knus/compare/v3.2.0...v3.3.1
 [3.2.0]: https://github.com/TheLostLambda/knus/releases/tag/v3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [3.3.0] - 2025-04-30
+
 ### Added
 
 - Implemented common `std` library traits for all public types (#5)
@@ -13,13 +15,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Changed
 
 - Made the fields of `knus::ast::Integer` and `knus::ast::Decimal` public (#1)
+- Changed `parse_*` functions to take `file_name: impl AsRef<str>` to match `miette` (#18)
 
 ### Fixed
-- Upgraded to `miette` v7.2.0, fixing several graphical bugs when reporting errors (#3)
+- Upgraded to `miette` v7.6.0, fixing several graphical bugs when reporting errors (#3)
+- Improved macro hygiene to avoid clashing with imported `Result` aliases (#19)
 
 ## [3.2.0] - 2024-10-24
 
 The beginning of time — this version is identical to [`knuffel` v3.2.0](https://crates.io/crates/knuffel/3.2.0).
 
-[unreleased]: https://github.com/TheLostLambda/knus/compare/v3.2.0...HEAD
+[unreleased]: https://github.com/TheLostLambda/knus/compare/v3.3.0...HEAD
+[3.3.0]: https://github.com/TheLostLambda/knus/releases/tag/v3.2.0...v3.3.0
 [3.2.0]: https://github.com/TheLostLambda/knus/releases/tag/v3.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 [package]
 name = "knus"
 version = "3.3.0"
-edition = "2021"
+edition = "2024"
 description = """
     Another KDL language implementation
 """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "knus"
-version = "3.3.0"
+version = "3.3.1"
 edition = "2024"
 description = """
     Another KDL language implementation
@@ -20,7 +20,7 @@ readme = "README.md"
 
 [dependencies]
 chumsky = { version="0.9.3", default-features=false }
-knus-derive = { path="./derive", version= "^3.2.0", optional=true }
+knus-derive = { path="./derive", version= "3.3.1", optional=true }
 base64 = { version="0.22.1", optional=true }
 unicode-width = { version="0.2.0", optional=true }
 minicbor = { version="0.26.5", optional=true, features=["std", "derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "knus"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2021"
 description = """
     Another KDL language implementation
@@ -16,7 +16,6 @@ keywords = ["kdl", "configuration", "parser"]
 categories = ["parser-implementations", "config", "encoding"]
 homepage = "https://github.com/TheLostLambda/knus"
 documentation = "https://docs.rs/knus"
-rust-version = "1.62.0"
 readme = "README.md"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,12 +24,12 @@ chumsky = { version="0.9.3", default-features=false }
 knus-derive = { path="./derive", version= "^3.2.0", optional=true }
 base64 = { version="0.22.1", optional=true }
 unicode-width = { version="0.2.0", optional=true }
-minicbor = { version="0.25.1", optional=true, features=["std", "derive"] }
-miette = "7.2.0"
-thiserror = "1.0.65"
+minicbor = { version="0.26.5", optional=true, features=["std", "derive"] }
+miette = "7.6.0"
+thiserror = "2.0.12"
 
 [dev-dependencies]
-miette = { version="7.2.0", features=["fancy"] }
+miette = { version="7.6.0", features=["fancy"] }
 assert-json-diff = "2.0.2"
 serde_json = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,9 @@ members = [
     "derive",
 ]
 
+[workspace.lints.rust]
+unused_assignments = "allow" # Workaround for https://github.com/rust-lang/rust/issues/147648
+
 [package]
 name = "knus"
 version = "3.3.1"
@@ -17,6 +20,9 @@ categories = ["parser-implementations", "config", "encoding"]
 homepage = "https://github.com/TheLostLambda/knus"
 documentation = "https://docs.rs/knus"
 readme = "README.md"
+
+[lints]
+workspace = true
 
 [dependencies]
 chumsky = { version="0.9.3", default-features=false }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 A [KDL](https://kdl.dev) file format parser with great error reporting and
 convenient derive macros.
 
+# Repo Maintenance
+
+In brief, I'll be around to review and merge PRs, but I may not have much time to fix issues / write code myself.
+I'm currently working on a successor to `knus` in the form of `facet-kdl` (which will greatly reduce the burden of maintenance by reusing `kdl-rs`s parsing code and `facet`s derive macro).
+
+In the meantime, I'm very happy to take on co-maintainers so that I'm not a single point of failure when it comes to merging PRs.
+That way I can be safely hit by a bus, and the `knus` community can carry on without another fork!
+
 # About KDL
 
 To give you some background on the KDL format. Here is a small example:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ convenient derive macros.
 # Repo Maintenance
 
 In brief, I'll be around to review and merge PRs, but I may not have much time to fix issues / write code myself.
-Others interested in the Rust-KDL ecosystem might want to help out with `facet-kdl` (which will greatly reduce the burden of maintenance by reusing `kdl-rs`s parsing code and `facet`s derive macro).
+At some point, it might be nice to merge `knus` with the `kdl-rs` reference implementation to significantly reduce the maintenance burden — we could bring the derive macro, they could bring the parser!
+It could also be possible to reuse some of the derive macro machinery from `facet`, but `facet` isn't currently interested in directly supporting KDL.
 
 In the meantime, I'm very happy to take on co-maintainers so that I'm not a single point of failure when it comes to merging PRs.
 That way I can be safely hit by a bus, and the `knus` community can carry on without another fork!

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ convenient derive macros.
 # Repo Maintenance
 
 In brief, I'll be around to review and merge PRs, but I may not have much time to fix issues / write code myself.
-I'm currently working on a successor to `knus` in the form of `facet-kdl` (which will greatly reduce the burden of maintenance by reusing `kdl-rs`s parsing code and `facet`s derive macro).
+Others interested in the Rust-KDL ecosystem might want to help out with `facet-kdl` (which will greatly reduce the burden of maintenance by reusing `kdl-rs`s parsing code and `facet`s derive macro).
 
 In the meantime, I'm very happy to take on co-maintainers so that I'm not a single point of failure when it comes to merging PRs.
 That way I can be safely hit by a bus, and the `knus` community can carry on without another fork!

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "knus-derive"
 version = "3.3.0"
-edition = "2021"
+edition = "2024"
 description = """
     A derive implementation for knus KDL parser
 """

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -16,11 +16,11 @@ proc-macro = true
 
 [dependencies]
 heck = { version="0.5.0" }
-syn = { version="2.0.85", features=["full", "extra-traits"] }
-quote = "1.0.37"
-proc-macro2 = "1.0.89"
+syn = { version="2.0.101", features=["full", "extra-traits"] }
+quote = "1.0.40"
+proc-macro2 = "1.0.95"
 proc-macro-error2 = "2.0.1"
 
 [dev-dependencies]
 knus = { path=".." }
-miette = { version="7.2.0", features=["fancy"] }
+miette = { version="7.6.0", features=["fancy"] }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "knus-derive"
-version = "3.3.0"
+version = "3.3.1"
 edition = "2024"
 description = """
     A derive implementation for knus KDL parser

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "knus-derive"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2021"
 description = """
     A derive implementation for knus KDL parser

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -11,6 +11,9 @@ homepage = "https://github.com/TheLostLambda/knus"
 documentation = "https://docs.rs/knus"
 readme = "README.md"
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/derive/derive_decode.md
+++ b/derive/derive_decode.md
@@ -596,10 +596,10 @@ There are few limitations of the `flatten`:
 3. Only children an properties can be factored out, not arguments in current
    implementation
 4. You must specify which directives can be used in the target structure
-    (i.e. `flatten(child, children, property, properties)`) and if `children`
-    or `properties` are forwarded to the target structure, no more children
-    and property attributes can be used in this structure following the
-    `flatten` attribute.
+   (i.e. `flatten(child, children, property, properties)`) and if `children`
+   or `properties` are forwarded to the target structure, no more children
+   and property attributes can be used in this structure following the
+   `flatten` attribute.
 
 We may lift some of these limitations later.
 

--- a/derive/src/definition.rs
+++ b/derive/src/definition.rs
@@ -1,8 +1,8 @@
 use std::fmt;
 use std::mem;
 
-use proc_macro2::{Span, TokenStream};
 use proc_macro_error2::emit_error;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::ext::IdentExt;
 use syn::parse::{Parse, ParseStream};
@@ -798,7 +798,7 @@ fn parse_attr_list(attrs: &[syn::Attribute]) -> Vec<(Attr, Span)> {
     all
 }
 
-fn parse_attrs(input: ParseStream) -> syn::Result<impl IntoIterator<Item = (Attr, Span)>> {
+fn parse_attrs(input: ParseStream) -> syn::Result<impl IntoIterator<Item = (Attr, Span)> + use<>> {
     Punctuated::<_, syn::Token![,]>::parse_terminated_with(input, Attr::parse)
 }
 

--- a/derive/src/definition.rs
+++ b/derive/src/definition.rs
@@ -22,7 +22,7 @@ pub enum Definition {
 pub enum VariantKind {
     Unit,
     Nested { option: bool },
-    Tuple(Struct),
+    Tuple(Box<Struct>),
     Named,
 }
 
@@ -315,7 +315,7 @@ impl Enum {
                             option: tup.extra_fields[0].option,
                         }
                     } else {
-                        VariantKind::Tuple(tup)
+                        VariantKind::Tuple(Box::new(tup))
                     }
                 }
                 syn::Fields::Unit => VariantKind::Unit,

--- a/derive/src/definition.rs
+++ b/derive/src/definition.rs
@@ -23,7 +23,7 @@ pub enum VariantKind {
     Unit,
     Nested { option: bool },
     Tuple(Box<Struct>),
-    Named,
+    Named(Box<Struct>),
 }
 
 pub enum ArgKind {
@@ -296,7 +296,15 @@ impl Enum {
                 continue;
             }
             let kind = match var.fields {
-                syn::Fields::Named(_) => VariantKind::Named,
+                syn::Fields::Named(n) => {
+                    let tup = Struct::new(
+                        var.ident.clone(),
+                        trait_props.clone(),
+                        generics.clone(),
+                        n.named.into_iter(),
+                    )?;
+                    VariantKind::Named(Box::new(tup))
+                }
                 syn::Fields::Unnamed(u) => {
                     let tup = Struct::new(
                         var.ident.clone(),

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -7,7 +7,7 @@ mod scalar;
 mod variants;
 
 use definition::Definition;
-use scalar::{emit_scalar, Scalar};
+use scalar::{Scalar, emit_scalar};
 
 fn emit_decoder(def: &Definition) -> syn::Result<TokenStream> {
     match def {

--- a/derive/src/node.rs
+++ b/derive/src/node.rs
@@ -1,5 +1,5 @@
 use proc_macro2::{Span, TokenStream};
-use quote::{format_ident, quote, ToTokens};
+use quote::{ToTokens, format_ident, quote};
 use syn::ext::IdentExt;
 
 use crate::definition::{ArgKind, DecodeMode, FieldAttrs, Struct, StructBuilder};

--- a/derive/src/scalar.rs
+++ b/derive/src/scalar.rs
@@ -102,7 +102,7 @@ pub fn emit_enum(e: &Enum) -> syn::Result<TokenStream> {
                 -> ::std::result::Result<#e_name, ::knus::errors::DecodeError<S>>
             {
                 match &**val {
-                    ::knus::ast::Literal::String(ref s) => {
+                    ::knus::ast::Literal::String(s) => {
                         match &s[..] {
                             #(#match_branches,)*
                             _ => {

--- a/derive/src/variants.rs
+++ b/derive/src/variants.rs
@@ -132,7 +132,18 @@ fn decode(e: &Common, node: &syn::Ident) -> syn::Result<TokenStream> {
                     #name => { #decode }
                 });
             }
-            VariantKind::Named => unimplemented!(),
+            VariantKind::Named(s) => {
+                let common = node::Common {
+                    object: s,
+                    ctx,
+                    span_type: e.span_type,
+                };
+                let decode =
+                    node::decode_enum_item(&common, quote!(#enum_name::#variant_name), node, true)?;
+                branches.push(quote! {
+                    #name => { #decode }
+                });
+            }
         }
     }
     // TODO(tailhook) use strsim to find similar names

--- a/derive/tests/enums.rs
+++ b/derive/tests/enums.rs
@@ -1,0 +1,36 @@
+use knus::{Decode, span::Span};
+
+#[derive(knus_derive::Decode, PartialEq, Debug)]
+enum Test {
+    A(
+        #[knus(property(name = "named"))] String,
+        #[knus(argument)] String,
+    ),
+    B {
+        #[knus(property)]
+        named: String,
+        #[knus(argument)]
+        arg: String,
+    },
+}
+
+fn parse<T: Decode<Span>>(text: &str) -> T {
+    let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
+    assert_eq!(nodes.len(), 1);
+    nodes.remove(0)
+}
+
+#[test]
+fn parse_enum() {
+    assert_eq!(
+        parse::<Test>(r#"a named="aaa" "bbb""#),
+        Test::A("aaa".to_owned(), "bbb".to_owned())
+    );
+    assert_eq!(
+        parse::<Test>(r#"b named="aaa" "bbb""#),
+        Test::B {
+            named: "aaa".to_owned(),
+            arg: "bbb".to_owned()
+        }
+    );
+}

--- a/derive/tests/flatten.rs
+++ b/derive/tests/flatten.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use miette::Diagnostic;
 
 use knus::traits::DecodeChildren;
-use knus::{span::Span, Decode};
+use knus::{Decode, span::Span};
 
 #[derive(knus_derive::Decode, Default, Debug, PartialEq)]
 struct Prop1 {

--- a/derive/tests/normal.rs
+++ b/derive/tests/normal.rs
@@ -5,7 +5,7 @@ use std::fmt;
 use miette::Diagnostic;
 
 use knus::traits::DecodeChildren;
-use knus::{span::Span, Decode};
+use knus::{Decode, span::Span};
 
 #[derive(knus_derive::Decode, Debug, PartialEq)]
 struct Arg1 {

--- a/derive/tests/normal.rs
+++ b/derive/tests/normal.rs
@@ -320,7 +320,7 @@ fn parse_arg_def_value() {
         }
     );
     assert_eq!(
-        parse::<ArgDefOptValue>(r#"node null"#),
+        parse::<ArgDefOptValue>(r#"node #null"#),
         ArgDefOptValue { name: None }
     );
 }
@@ -334,7 +334,7 @@ fn parse_opt_arg() {
         }
     );
     assert_eq!(parse::<OptArg>(r#"node"#), OptArg { name: None });
-    assert_eq!(parse::<OptArg>(r#"node null"#), OptArg { name: None });
+    assert_eq!(parse::<OptArg>(r#"node #null"#), OptArg { name: None });
 }
 
 #[test]
@@ -412,7 +412,7 @@ fn parse_prop_def_value() {
         }
     );
     assert_eq!(
-        parse::<PropDefOptValue>(r#"node label=null"#),
+        parse::<PropDefOptValue>(r#"node label=#null"#),
         PropDefOptValue { label: None }
     );
 }
@@ -519,7 +519,7 @@ fn parse_opt_prop() {
     );
     assert_eq!(parse::<OptProp>(r#"node"#), OptProp { label: None });
     assert_eq!(
-        parse::<OptProp>(r#"node label=null"#),
+        parse::<OptProp>(r#"node label=#null"#),
         OptProp { label: None }
     );
 }
@@ -803,7 +803,7 @@ fn parse_str() {
     );
     assert!(parse_err::<ParseOpt>(r#"server listen="2/3""#).contains("invalid"));
     assert_eq!(
-        parse::<ParseOpt>(r#"server listen=null"#),
+        parse::<ParseOpt>(r#"server listen=#null"#),
         ParseOpt { listen: None }
     );
 }
@@ -840,7 +840,7 @@ fn parse_bytes() {
         }
     );
     assert_eq!(
-        parse::<OptBytes>(r#"node data=null"#),
+        parse::<OptBytes>(r#"node data=#null"#),
         OptBytes { data: None }
     );
 }

--- a/derive/tests/scalar.rs
+++ b/derive/tests/scalar.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
-use knus::span::Span;
 use knus::Decode;
+use knus::span::Span;
 use miette::Diagnostic;
 
 #[derive(knus::DecodeScalar, Debug, PartialEq)]

--- a/derive/tests/tuples.rs
+++ b/derive/tests/tuples.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use miette::Diagnostic;
 
-use knus::{span::Span, Decode};
+use knus::{Decode, span::Span};
 
 #[derive(Debug, Decode, PartialEq)]
 struct Unit;

--- a/derive/tests/types.rs
+++ b/derive/tests/types.rs
@@ -30,7 +30,7 @@ fn parse_enum() {
             u64 1234
             f64 16.125e+1
             path "/hello/world"
-            boolean true
+            boolean #true
         "#
         ),
         Scalars {

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -29,7 +29,7 @@ macro_rules! impl_integer {
                 ctx: &mut Context<S>,
             ) -> Result<$typ, DecodeError<S>> {
                 match &**val {
-                    Literal::Int(ref value) => match value.try_into() {
+                    Literal::Int(value) => match value.try_into() {
                         Ok(val) => Ok(val),
                         Err(e) => {
                             ctx.emit_error(DecodeError::conversion(val, e));
@@ -84,7 +84,7 @@ macro_rules! impl_float {
                 ctx: &mut Context<S>,
             ) -> Result<$typ, DecodeError<S>> {
                 match &**val {
-                    Literal::Decimal(ref value) => match value.try_into() {
+                    Literal::Decimal(value) => match value.try_into() {
                         Ok(val) => Ok(val),
                         Err(e) => {
                             ctx.emit_error(DecodeError::conversion(val, e));
@@ -122,7 +122,7 @@ impl<S: ErrorSpan> DecodeScalar<S> for String {
         ctx: &mut Context<S>,
     ) -> Result<String, DecodeError<S>> {
         match &**val {
-            Literal::String(ref s) => Ok(s.clone().into()),
+            Literal::String(s) => Ok(s.clone().into()),
             _ => {
                 ctx.emit_error(DecodeError::scalar_kind(Kind::String, val));
                 Ok(String::new())
@@ -147,7 +147,7 @@ impl<S: ErrorSpan> DecodeScalar<S> for PathBuf {
         ctx: &mut Context<S>,
     ) -> Result<PathBuf, DecodeError<S>> {
         match &**val {
-            Literal::String(ref s) => Ok(String::from(s.clone()).into()),
+            Literal::String(s) => Ok(String::from(s.clone()).into()),
             _ => {
                 ctx.emit_error(DecodeError::scalar_kind(Kind::String, val));
                 Ok(Default::default())
@@ -172,7 +172,7 @@ impl<S: ErrorSpan> DecodeScalar<S> for Arc<Path> {
         ctx: &mut Context<S>,
     ) -> Result<Arc<Path>, DecodeError<S>> {
         match &**val {
-            Literal::String(ref s) => Ok(PathBuf::from(&(**s)[..]).into()),
+            Literal::String(s) => Ok(PathBuf::from(&(**s)[..]).into()),
             _ => {
                 ctx.emit_error(DecodeError::scalar_kind(Kind::String, val));
                 Ok(PathBuf::default().into())
@@ -197,7 +197,7 @@ impl<S: ErrorSpan> DecodeScalar<S> for Arc<str> {
         ctx: &mut Context<S>,
     ) -> Result<Arc<str>, DecodeError<S>> {
         match &**val {
-            Literal::String(ref s) => Ok(s.clone().into()),
+            Literal::String(s) => Ok(s.clone().into()),
             _ => {
                 ctx.emit_error(DecodeError::scalar_kind(Kind::String, val));
                 Ok(String::default().into())

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -52,7 +52,7 @@ pub fn bytes<S: ErrorSpan>(value: &Value<S>, ctx: &mut Context<S>) -> Vec<u8> {
             Some(&BuiltinType::Base64) => {
                 #[cfg(feature = "base64")]
                 {
-                    use base64::{engine::general_purpose::STANDARD, Engine};
+                    use base64::{Engine, engine::general_purpose::STANDARD};
                     match &*value.literal {
                         Literal::String(s) => match STANDARD.decode(s.as_bytes()) {
                             Ok(vec) => vec,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -278,30 +278,21 @@ impl fmt::Display for FormatUnexpected<'_> {
 impl<S: ErrorSpan> ParseError<S> {
     pub(crate) fn with_expected_token(mut self, token: &'static str) -> Self {
         use ParseError::*;
-        if let Unexpected {
-            ref mut expected, ..
-        } = &mut self
-        {
+        if let Unexpected { expected, .. } = &mut self {
             *expected = [TokenFormat::Token(token)].into_iter().collect();
         }
         self
     }
     pub(crate) fn with_expected_kind(mut self, token: &'static str) -> Self {
         use ParseError::*;
-        if let Unexpected {
-            ref mut expected, ..
-        } = &mut self
-        {
+        if let Unexpected { expected, .. } = &mut self {
             *expected = [TokenFormat::Kind(token)].into_iter().collect();
         }
         self
     }
     pub(crate) fn with_no_expected(mut self) -> Self {
         use ParseError::*;
-        if let Unexpected {
-            ref mut expected, ..
-        } = &mut self
-        {
+        if let Unexpected { expected, .. } = &mut self {
             *expected = BTreeSet::new();
         }
         self
@@ -392,13 +383,7 @@ impl<S: Span> chumsky::Error<char> for ParseError<S> {
         match (&mut self, other) {
             (Unclosed { .. }, _) => self,
             (_, other @ Unclosed { .. }) => other,
-            (
-                Unexpected {
-                    expected: ref mut dest,
-                    ..
-                },
-                Unexpected { expected, .. },
-            ) => {
+            (Unexpected { expected: dest, .. }, Unexpected { expected, .. }) => {
                 dest.extend(expected);
                 self
             }

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -628,11 +628,7 @@ fn nodes<S: Span>() -> impl Parser<char, Vec<SpannedNode<S>>, Error = Error<S>> 
                 vec.into_iter()
                     .filter_map(
                         |(comment, node)| {
-                            if comment.is_none() {
-                                Some(node)
-                            } else {
-                                None
-                            }
+                            if comment.is_none() { Some(node) } else { None }
                         },
                     )
                     .collect()
@@ -656,7 +652,7 @@ mod test {
     use miette::NamedSource;
 
     macro_rules! err_eq {
-        ($left: expr, $right: expr) => {
+        ($left: expr_2021, $right: expr_2021) => {
             let left = $left.unwrap_err();
             let left: serde_json::Value = serde_json::from_str(&left).unwrap();
             let right: serde_json::Value =

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -928,7 +928,6 @@ mod test {
 
     #[test]
     fn parse_str() {
-        //assert_eq!(&*parse(string(), r#"hello"#).unwrap(), "hello");
         assert_eq!(&*parse(string(), r#""hello""#).unwrap(), "hello");
         assert_eq!(&*parse(string(), r#""""#).unwrap(), "");
         assert_eq!(&*parse(string(), r#""hel\"lo""#).unwrap(), "hel\"lo");
@@ -1604,6 +1603,27 @@ mod test {
                     "span": {"offset": 5, "length": 1}},
                     {"label": "expected `}`",
                     "span": {"offset": 6, "length": 0}}
+                ],
+                "related": []
+            }]
+        }"#
+        );
+
+        err_eq!(
+            parse(nodes(), "hello world {"),
+            r#"{
+            "message": "error parsing KDL",
+            "severity": "error",
+            "labels": [],
+            "related": [{
+                "message": "unclosed curly braces `{`",
+                "severity": "error",
+                "filename": "<test>",
+                "labels": [
+                    {"label": "opened here",
+                    "span": {"offset": 12, "length": 1}},
+                    {"label": "expected `}`",
+                    "span": {"offset": 13, "length": 0}}
                 ],
                 "related": []
             }]


### PR DESCRIPTION
We're doing a [back-merge](https://stackoverflow.com/questions/47555448/what-is-a-back-merge) to get the CI fixes from `main` into `kdl-v2`. And then we fix the tests.

---

In order to make the tests pass, I introduced small diagnostics regressions in these two tests

- `"he\x01llo"`
- `"he\u{FFFFFF}l\!lo"`

These two diagnostics regressions are fixed by follow-up PRs.

---

There are also some other tests modified and deleted, but those changes are not from my commits. Nevertheless, we can discuss what to maybe change there.