### PR TITLE
Use only one kind of span within the parser

### DIFF
--- a/derive/derive_decode.md
+++ b/derive/derive_decode.md
@@ -735,7 +735,7 @@ Enum variant names are matches against node names converted into `kebab-case`.
 
 ## Span Type
 
-But if you want to use `span` argument, you need to specify a field
+If you want to use the `span` argument, you need to specify a field
 with the type `knus::span::Span` or provide a custom type that
 implements `DecodeSpan`.
 

--- a/derive/derive_decode.md
+++ b/derive/derive_decode.md
@@ -676,10 +676,9 @@ Node name always exists so optional node_name is not supported.
 
 The following definition:
 ```rust
-use knus::span::Span;  // or LineSpan
+use knus::span::Span;
 
 #[derive(knus::Decode)]
-#[knus(span_type=Span)]
 struct Node {
     #[knus(span)]
     span: Span,  // This can be user type decoded from Span
@@ -693,11 +692,8 @@ newline if node ends by a newline, but doesn't include anything after
 semicolon).
 
 The span value might be different than one used for parsing. In this case, it
-should implement [`DecodeSpan`](traits/trait.DecodeSpan.html) trait.
-
-Independenly of whether you use custom span type, or built-in one, you have to
-specify `span_type` for the decoder, since there is no generic implementation
-of the `DecodeSpan` for any type. See [Span Type](#span-type) for more info
+should implement [`DecodeSpan`](traits/trait.DecodeSpan.html) trait. See
+[Span Type](#span-type) for more info
 
 # Enums
 
@@ -739,30 +735,33 @@ Enum variant names are matches against node names converted into `kebab-case`.
 
 ## Span Type
 
-Usually generated implemenation is for any span type:
-```rust,ignore
-impl Decode<S> for MyStruct {
-   # ...
-}
-```
-But if you want to use `span` argument, it's unlikely to be possible to
-implement `DecodeSpan` for any type.
+But if you want to use `span` argument, you need to specify a field
+with the type `knus::span::Span` or provide a custom type that
+implements `DecodeSpan`.
 
-Use use `span_type=` for implemenation of specific type:
 ```rust
-use knus::span::Span;  // or LineSpan
+use knus::decode::Context;
+use knus::span::Span;
+use knus::traits::DecodeSpan;
+
+struct MySpan {
+    start: usize,
+    end: usize,
+}
+
+impl DecodeSpan for MySpan {
+    fn decode_span(span: &Span, _ctx: &mut Context) -> Self {
+        MySpan {
+            start: span.0,
+            end: span.1,
+        }
+    }
+}
 
 #[derive(knus::Decode)]
-#[knus(span_type=Span)]
 struct MyStruct {
     #[knus(span)]
-    span: Span,
-}
-```
-This will generate implementation like this:
-```rust,ignore
-impl Decode<Span> for MyStruct {
-   # ...
+    span: MySpan,
 }
 ```
 

--- a/derive/src/kw.rs
+++ b/derive/src/kw.rs
@@ -11,7 +11,6 @@ syn::custom_keyword!(properties);
 syn::custom_keyword!(property);
 syn::custom_keyword!(skip);
 syn::custom_keyword!(span);
-syn::custom_keyword!(span_type);
 syn::custom_keyword!(str);
 syn::custom_keyword!(type_name);
 syn::custom_keyword!(unwrap);

--- a/derive/src/node.rs
+++ b/derive/src/node.rs
@@ -220,7 +220,7 @@ fn decode_value(
             Ok(quote![{
                 if let Some(typ) = &#val.type_name {
                     #ctx.emit_error(::knus::errors::DecodeError::TypeName {
-                        span: typ.span().clone(),
+                        span: *typ.span(),
                         found: Some((**typ).clone()),
                         expected: ::knus::errors::ExpectedType::no_type(),
                         rust_type: "str", // TODO(tailhook) show field type
@@ -251,7 +251,7 @@ fn decode_value(
             Ok(quote![{
                 if let Some(typ) = &#val.type_name {
                     #ctx.emit_error(::knus::errors::DecodeError::TypeName {
-                        span: typ.span().clone(),
+                        span: *typ.span(),
                         found: Some((**typ).clone()),
                         expected: ::knus::errors::ExpectedType::no_type(),
                         rust_type: "str", // TODO(tailhook) show field type
@@ -841,7 +841,7 @@ fn decode_children(
                         postprocess.push(quote! {
                             let #fld = #fld.ok_or_else(|| {
                                 ::knus::errors::DecodeError::Missing {
-                                    span: #span.clone(),
+                                    span: *#span,
                                     message: #req_msg.into(),
                                 }
                             })?;

--- a/derive/src/scalar.rs
+++ b/derive/src/scalar.rs
@@ -124,7 +124,7 @@ pub fn emit_enum(e: &Enum) -> syn::Result<TokenStream> {
             {
                 if let Some(typ) = type_name {
                     ctx.emit_error(::knus::errors::DecodeError::TypeName {
-                        span: typ.span().clone(),
+                        span: *typ.span(),
                         found: Some((**typ).clone()),
                         expected: ::knus::errors::ExpectedType::no_type(),
                         rust_type: stringify!(#e_name),

--- a/derive/src/scalar.rs
+++ b/derive/src/scalar.rs
@@ -94,12 +94,11 @@ pub fn emit_enum(e: &Enum) -> syn::Result<TokenStream> {
         quote!(#name => Ok(#e_name::#ident))
     });
     Ok(quote! {
-        impl<S: ::knus::traits::ErrorSpan> ::knus::DecodeScalar<S>
-                for #e_name {
+        impl ::knus::DecodeScalar for #e_name {
             fn raw_decode(val: &::knus::span::Spanned<
-                          ::knus::ast::Literal, S>,
-                          ctx: &mut ::knus::decode::Context<S>)
-                -> ::std::result::Result<#e_name, ::knus::errors::DecodeError<S>>
+                          ::knus::ast::Literal>,
+                          ctx: &mut ::knus::decode::Context)
+                -> ::std::result::Result<#e_name, ::knus::errors::DecodeError>
             {
                 match &**val {
                     ::knus::ast::Literal::String(s) => {
@@ -120,8 +119,8 @@ pub fn emit_enum(e: &Enum) -> syn::Result<TokenStream> {
                 }
             }
             fn type_check(type_name: &Option<::knus::span::Spanned<
-                          ::knus::ast::TypeName, S>>,
-                          ctx: &mut ::knus::decode::Context<S>)
+                          ::knus::ast::TypeName>>,
+                          ctx: &mut ::knus::decode::Context)
             {
                 if let Some(typ) = type_name {
                     ctx.emit_error(::knus::errors::DecodeError::TypeName {

--- a/derive/tests/ast.rs
+++ b/derive/tests/ast.rs
@@ -1,14 +1,12 @@
-use knus::span::Span;
 use knus::traits::Decode;
 
 #[derive(knus_derive::Decode, Debug)]
-#[knus(span_type=knus::span::Span)]
 struct AstChildren {
     #[knus(children)]
-    children: Vec<knus::ast::SpannedNode<Span>>,
+    children: Vec<knus::ast::SpannedNode>,
 }
 
-fn parse<T: Decode<Span>>(text: &str) -> T {
+fn parse<T: Decode>(text: &str) -> T {
     let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
     assert_eq!(nodes.len(), 1);
     nodes.remove(0)

--- a/derive/tests/custom_span.rs
+++ b/derive/tests/custom_span.rs
@@ -1,0 +1,46 @@
+use knus::decode::Context;
+use knus::span::Span;
+use knus::traits::{Decode, DecodeSpan};
+
+#[derive(Debug, PartialEq)]
+struct MySpan {
+    start: usize,
+    end: usize,
+}
+
+impl DecodeSpan for MySpan {
+    fn decode_span(span: &Span, _ctx: &mut Context) -> Self {
+        MySpan {
+            start: span.0,
+            end: span.1,
+        }
+    }
+}
+
+#[derive(knus_derive::Decode, Debug, PartialEq)]
+struct NodeSpan {
+    #[knus(span)]
+    span: MySpan,
+}
+
+fn parse<T: Decode>(text: &str) -> T {
+    let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
+    assert_eq!(nodes.len(), 1);
+    nodes.remove(0)
+}
+
+#[test]
+fn parse_node_span() {
+    assert_eq!(
+        parse::<NodeSpan>(r#"node"#),
+        NodeSpan {
+            span: MySpan { start: 0, end: 4 },
+        }
+    );
+    assert_eq!(
+        parse::<NodeSpan>(r#"   node  "#),
+        NodeSpan {
+            span: MySpan { start: 3, end: 9 },
+        }
+    );
+}

--- a/derive/tests/enums.rs
+++ b/derive/tests/enums.rs
@@ -1,4 +1,4 @@
-use knus::{Decode, span::Span};
+use knus::Decode;
 
 #[derive(knus_derive::Decode, PartialEq, Debug)]
 enum Test {
@@ -14,7 +14,7 @@ enum Test {
     },
 }
 
-fn parse<T: Decode<Span>>(text: &str) -> T {
+fn parse<T: Decode>(text: &str) -> T {
     let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
     assert_eq!(nodes.len(), 1);
     nodes.remove(0)

--- a/derive/tests/extra.rs
+++ b/derive/tests/extra.rs
@@ -6,7 +6,6 @@ use knus::traits::Decode;
 struct Child;
 
 #[derive(knus_derive::Decode, Debug, PartialEq)]
-#[knus(span_type=Span)]
 struct NodeSpan {
     #[knus(span)]
     span: Span,
@@ -30,7 +29,7 @@ struct NameAndType {
     type_name: Option<TypeName>,
 }
 
-fn parse<T: Decode<Span>>(text: &str) -> T {
+fn parse<T: Decode>(text: &str) -> T {
     let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
     assert_eq!(nodes.len(), 1);
     nodes.remove(0)

--- a/derive/tests/flatten.rs
+++ b/derive/tests/flatten.rs
@@ -2,8 +2,8 @@ use std::fmt;
 
 use miette::Diagnostic;
 
+use knus::Decode;
 use knus::traits::DecodeChildren;
-use knus::{Decode, span::Span};
 
 #[derive(knus_derive::Decode, Default, Debug, PartialEq)]
 struct Prop1 {
@@ -29,13 +29,13 @@ struct FlatChild {
     children: Unwrap,
 }
 
-fn parse<T: Decode<Span>>(text: &str) -> T {
+fn parse<T: Decode>(text: &str) -> T {
     let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
     assert_eq!(nodes.len(), 1);
     nodes.remove(0)
 }
 
-fn parse_err<T: Decode<Span> + fmt::Debug>(text: &str) -> String {
+fn parse_err<T: Decode + fmt::Debug>(text: &str) -> String {
     let err = knus::parse::<Vec<T>>("<test>", text).unwrap_err();
     err.related()
         .unwrap()
@@ -44,11 +44,11 @@ fn parse_err<T: Decode<Span> + fmt::Debug>(text: &str) -> String {
         .join("\n")
 }
 
-fn parse_doc<T: DecodeChildren<Span>>(text: &str) -> T {
+fn parse_doc<T: DecodeChildren>(text: &str) -> T {
     knus::parse("<test>", text).unwrap()
 }
 
-fn parse_doc_err<T: DecodeChildren<Span> + fmt::Debug>(text: &str) -> String {
+fn parse_doc_err<T: DecodeChildren + fmt::Debug>(text: &str) -> String {
     let err = knus::parse::<T>("<test>", text).unwrap_err();
     err.related()
         .unwrap()

--- a/derive/tests/normal.rs
+++ b/derive/tests/normal.rs
@@ -4,8 +4,8 @@ use std::fmt;
 
 use miette::Diagnostic;
 
+use knus::Decode;
 use knus::traits::DecodeChildren;
-use knus::{Decode, span::Span};
 
 #[derive(knus_derive::Decode, Debug, PartialEq)]
 struct Arg1 {
@@ -197,13 +197,13 @@ struct OptBytes {
     data: Option<Vec<u8>>,
 }
 
-fn parse<T: Decode<Span>>(text: &str) -> T {
+fn parse<T: Decode>(text: &str) -> T {
     let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
     assert_eq!(nodes.len(), 1);
     nodes.remove(0)
 }
 
-fn parse_err<T: Decode<Span> + fmt::Debug>(text: &str) -> String {
+fn parse_err<T: Decode + fmt::Debug>(text: &str) -> String {
     let err = knus::parse::<Vec<T>>("<test>", text).unwrap_err();
     err.related()
         .unwrap()
@@ -212,11 +212,11 @@ fn parse_err<T: Decode<Span> + fmt::Debug>(text: &str) -> String {
         .join("\n")
 }
 
-fn parse_doc<T: DecodeChildren<Span>>(text: &str) -> T {
+fn parse_doc<T: DecodeChildren>(text: &str) -> T {
     knus::parse("<test>", text).unwrap()
 }
 
-fn parse_doc_err<T: DecodeChildren<Span> + fmt::Debug>(text: &str) -> String {
+fn parse_doc_err<T: DecodeChildren + fmt::Debug>(text: &str) -> String {
     let err = knus::parse::<T>("<test>", text).unwrap_err();
     err.related()
         .unwrap()

--- a/derive/tests/scalar.rs
+++ b/derive/tests/scalar.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
 use knus::Decode;
-use knus::span::Span;
 use miette::Diagnostic;
 
 #[derive(knus::DecodeScalar, Debug, PartialEq)]
@@ -16,13 +15,13 @@ struct Item {
     value: SomeScalar,
 }
 
-fn parse<T: Decode<Span>>(text: &str) -> T {
+fn parse<T: Decode>(text: &str) -> T {
     let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
     assert_eq!(nodes.len(), 1);
     nodes.remove(0)
 }
 
-fn parse_err<T: Decode<Span> + fmt::Debug>(text: &str) -> String {
+fn parse_err<T: Decode + fmt::Debug>(text: &str) -> String {
     let err = knus::parse::<Vec<T>>("<test>", text).unwrap_err();
     err.related()
         .unwrap()

--- a/derive/tests/tuples.rs
+++ b/derive/tests/tuples.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use miette::Diagnostic;
 
-use knus::{Decode, span::Span};
+use knus::Decode;
 
 #[derive(Debug, Decode, PartialEq)]
 struct Unit;
@@ -24,13 +24,13 @@ enum Enum {
     Extra(#[knus(argument)] Option<String>, u32),
 }
 
-fn parse<T: Decode<Span>>(text: &str) -> T {
+fn parse<T: Decode>(text: &str) -> T {
     let mut nodes: Vec<T> = knus::parse("<test>", text).unwrap();
     assert_eq!(nodes.len(), 1);
     nodes.remove(0)
 }
 
-fn parse_err<T: Decode<Span> + fmt::Debug>(text: &str) -> String {
+fn parse_err<T: Decode + fmt::Debug>(text: &str) -> String {
     let err = knus::parse::<Vec<T>>("<test>", text).unwrap_err();
     err.related()
         .unwrap()

--- a/derive/tests/types.rs
+++ b/derive/tests/types.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use knus::span::Span;
 use knus::traits::DecodeChildren;
 
 #[derive(knus_derive::Decode, Debug, PartialEq)]
@@ -17,7 +16,7 @@ struct Scalars {
     boolean: bool,
 }
 
-fn parse<T: DecodeChildren<Span>>(text: &str) -> T {
+fn parse<T: DecodeChildren>(text: &str) -> T {
     knus::parse("<test>", text).unwrap()
 }
 

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -20,40 +20,40 @@ use std::str::FromStr;
 use crate::span::Spanned;
 
 /// A shortcut for nodes children that includes span of enclosing braces `{..}`
-pub type SpannedChildren<S> = Spanned<Vec<SpannedNode<S>>, S>;
+pub type SpannedChildren = Spanned<Vec<SpannedNode>>;
 /// KDL names with span information are represented using this type
-pub type SpannedName<S> = Spanned<Box<str>, S>;
+pub type SpannedName = Spanned<Box<str>>;
 /// A KDL node with span of the whole node (including children)
-pub type SpannedNode<S> = Spanned<Node<S>, S>;
+pub type SpannedNode = Spanned<Node>;
 
 /// Single node of the KDL document
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
-pub struct Node<S> {
+pub struct Node {
     /// A type name if specified in parenthesis
     #[cfg_attr(feature = "minicbor", n(0))]
-    pub type_name: Option<Spanned<TypeName, S>>,
+    pub type_name: Option<Spanned<TypeName>>,
     /// A node name
     #[cfg_attr(feature = "minicbor", n(1))]
-    pub node_name: SpannedName<S>,
+    pub node_name: SpannedName,
     /// Positional arguments
     #[cfg_attr(feature = "minicbor", n(2))]
-    pub arguments: Vec<Value<S>>,
+    pub arguments: Vec<Value>,
     /// Named properties
     #[cfg_attr(feature = "minicbor", n(3))]
-    pub properties: BTreeMap<SpannedName<S>, Value<S>>,
+    pub properties: BTreeMap<SpannedName, Value>,
     /// Node's children. This field is not none if there are braces `{..}`
     #[cfg_attr(feature = "minicbor", n(4))]
-    pub children: Option<SpannedChildren<S>>,
+    pub children: Option<SpannedChildren>,
 }
 
 /// KDL document root
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
-pub struct Document<S> {
+pub struct Document {
     /// Nodes of the document
     #[cfg_attr(feature = "minicbor", n(0))]
-    pub nodes: Vec<SpannedNode<S>>,
+    pub nodes: Vec<SpannedNode>,
 }
 
 /// Possible integer radices described by the KDL specification
@@ -93,13 +93,13 @@ pub struct Decimal(#[cfg_attr(feature = "minicbor", n(0))] pub Box<str>);
 /// Possibly typed KDL scalar value
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
-pub struct Value<S> {
+pub struct Value {
     /// A type name if specified in parenthesis
     #[cfg_attr(feature = "minicbor", n(0))]
-    pub type_name: Option<Spanned<TypeName, S>>,
+    pub type_name: Option<Spanned<TypeName>>,
     /// The actual value literal
     #[cfg_attr(feature = "minicbor", n(1))]
-    pub literal: Spanned<Literal, S>,
+    pub literal: Spanned<Literal>,
 }
 
 /// Type identifier
@@ -183,9 +183,9 @@ pub enum Literal {
     NegInf,
 }
 
-impl<S> Node<S> {
+impl Node {
     /// Returns node children
-    pub fn children(&self) -> impl ExactSizeIterator<Item = &Spanned<Node<S>, S>> {
+    pub fn children(&self) -> impl ExactSizeIterator<Item = &Spanned<Node>> {
         self.children
             .as_ref()
             .map(|c| c.iter())

--- a/src/containers.rs
+++ b/src/containers.rs
@@ -5,157 +5,123 @@ use crate::ast::{Literal, SpannedNode, TypeName, Value};
 use crate::decode::Context;
 use crate::errors::DecodeError;
 use crate::span::Spanned;
-use crate::traits::{Decode, DecodeChildren, DecodePartial, DecodeScalar};
-use crate::traits::{DecodeSpan, ErrorSpan, Span};
+use crate::traits::{Decode, DecodeChildren, DecodePartial, DecodeScalar, DecodeSpan};
 
-impl<S: ErrorSpan, T: Decode<S>> Decode<S> for Box<T> {
-    fn decode_node(node: &SpannedNode<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>> {
+impl<T: Decode> Decode for Box<T> {
+    fn decode_node(node: &SpannedNode, ctx: &mut Context) -> Result<Self, DecodeError> {
         Decode::decode_node(node, ctx).map(Box::new)
     }
 }
 
-impl<S: ErrorSpan, T: DecodeChildren<S>> DecodeChildren<S> for Box<T> {
-    fn decode_children(
-        nodes: &[SpannedNode<S>],
-        ctx: &mut Context<S>,
-    ) -> Result<Self, DecodeError<S>> {
+impl<T: DecodeChildren> DecodeChildren for Box<T> {
+    fn decode_children(nodes: &[SpannedNode], ctx: &mut Context) -> Result<Self, DecodeError> {
         DecodeChildren::decode_children(nodes, ctx).map(Box::new)
     }
 }
 
-impl<S: ErrorSpan, T: DecodePartial<S>> DecodePartial<S> for Box<T> {
-    fn insert_child(
-        &mut self,
-        node: &SpannedNode<S>,
-        ctx: &mut Context<S>,
-    ) -> Result<bool, DecodeError<S>> {
+impl<T: DecodePartial> DecodePartial for Box<T> {
+    fn insert_child(&mut self, node: &SpannedNode, ctx: &mut Context) -> Result<bool, DecodeError> {
         (**self).insert_child(node, ctx)
     }
     fn insert_property(
         &mut self,
-        name: &Spanned<Box<str>, S>,
-        value: &Value<S>,
-        ctx: &mut Context<S>,
-    ) -> Result<bool, DecodeError<S>> {
+        name: &Spanned<Box<str>>,
+        value: &Value,
+        ctx: &mut Context,
+    ) -> Result<bool, DecodeError> {
         (**self).insert_property(name, value, ctx)
     }
 }
 
-impl<S: ErrorSpan, T: DecodeScalar<S>> DecodeScalar<S> for Box<T> {
-    fn type_check(type_name: &Option<Spanned<TypeName, S>>, ctx: &mut Context<S>) {
+impl<T: DecodeScalar> DecodeScalar for Box<T> {
+    fn type_check(type_name: &Option<Spanned<TypeName>>, ctx: &mut Context) {
         T::type_check(type_name, ctx)
     }
-    fn raw_decode(
-        value: &Spanned<Literal, S>,
-        ctx: &mut Context<S>,
-    ) -> Result<Self, DecodeError<S>> {
+    fn raw_decode(value: &Spanned<Literal>, ctx: &mut Context) -> Result<Self, DecodeError> {
         DecodeScalar::raw_decode(value, ctx).map(Box::new)
     }
 }
 
-impl<S: ErrorSpan, T: Decode<S>> Decode<S> for Arc<T> {
-    fn decode_node(node: &SpannedNode<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>> {
+impl<T: Decode> Decode for Arc<T> {
+    fn decode_node(node: &SpannedNode, ctx: &mut Context) -> Result<Self, DecodeError> {
         Decode::decode_node(node, ctx).map(Arc::new)
     }
 }
 
-impl<S: ErrorSpan, T: DecodeChildren<S>> DecodeChildren<S> for Arc<T> {
-    fn decode_children(
-        nodes: &[SpannedNode<S>],
-        ctx: &mut Context<S>,
-    ) -> Result<Self, DecodeError<S>> {
+impl<T: DecodeChildren> DecodeChildren for Arc<T> {
+    fn decode_children(nodes: &[SpannedNode], ctx: &mut Context) -> Result<Self, DecodeError> {
         DecodeChildren::decode_children(nodes, ctx).map(Arc::new)
     }
 }
 
-impl<S: ErrorSpan, T: DecodePartial<S>> DecodePartial<S> for Arc<T> {
-    fn insert_child(
-        &mut self,
-        node: &SpannedNode<S>,
-        ctx: &mut Context<S>,
-    ) -> Result<bool, DecodeError<S>> {
+impl<T: DecodePartial> DecodePartial for Arc<T> {
+    fn insert_child(&mut self, node: &SpannedNode, ctx: &mut Context) -> Result<bool, DecodeError> {
         Arc::get_mut(self)
             .expect("no Arc clone yet")
             .insert_child(node, ctx)
     }
     fn insert_property(
         &mut self,
-        name: &Spanned<Box<str>, S>,
-        value: &Value<S>,
-        ctx: &mut Context<S>,
-    ) -> Result<bool, DecodeError<S>> {
+        name: &Spanned<Box<str>>,
+        value: &Value,
+        ctx: &mut Context,
+    ) -> Result<bool, DecodeError> {
         Arc::get_mut(self)
             .expect("no Arc clone yet")
             .insert_property(name, value, ctx)
     }
 }
 
-impl<S: ErrorSpan, T: DecodeScalar<S>> DecodeScalar<S> for Arc<T> {
-    fn type_check(type_name: &Option<Spanned<TypeName, S>>, ctx: &mut Context<S>) {
+impl<T: DecodeScalar> DecodeScalar for Arc<T> {
+    fn type_check(type_name: &Option<Spanned<TypeName>>, ctx: &mut Context) {
         T::type_check(type_name, ctx)
     }
-    fn raw_decode(
-        value: &Spanned<Literal, S>,
-        ctx: &mut Context<S>,
-    ) -> Result<Self, DecodeError<S>> {
+    fn raw_decode(value: &Spanned<Literal>, ctx: &mut Context) -> Result<Self, DecodeError> {
         DecodeScalar::raw_decode(value, ctx).map(Arc::new)
     }
 }
 
-impl<S: ErrorSpan, T: Decode<S>> Decode<S> for Rc<T> {
-    fn decode_node(node: &SpannedNode<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>> {
+impl<T: Decode> Decode for Rc<T> {
+    fn decode_node(node: &SpannedNode, ctx: &mut Context) -> Result<Self, DecodeError> {
         Decode::decode_node(node, ctx).map(Rc::new)
     }
 }
 
-impl<S: ErrorSpan, T: DecodeChildren<S>> DecodeChildren<S> for Rc<T> {
-    fn decode_children(
-        nodes: &[SpannedNode<S>],
-        ctx: &mut Context<S>,
-    ) -> Result<Self, DecodeError<S>> {
+impl<T: DecodeChildren> DecodeChildren for Rc<T> {
+    fn decode_children(nodes: &[SpannedNode], ctx: &mut Context) -> Result<Self, DecodeError> {
         DecodeChildren::decode_children(nodes, ctx).map(Rc::new)
     }
 }
 
-impl<S: ErrorSpan, T: DecodePartial<S>> DecodePartial<S> for Rc<T> {
-    fn insert_child(
-        &mut self,
-        node: &SpannedNode<S>,
-        ctx: &mut Context<S>,
-    ) -> Result<bool, DecodeError<S>> {
+impl<T: DecodePartial> DecodePartial for Rc<T> {
+    fn insert_child(&mut self, node: &SpannedNode, ctx: &mut Context) -> Result<bool, DecodeError> {
         Rc::get_mut(self)
             .expect("no Rc clone yet")
             .insert_child(node, ctx)
     }
     fn insert_property(
         &mut self,
-        name: &Spanned<Box<str>, S>,
-        value: &Value<S>,
-        ctx: &mut Context<S>,
-    ) -> Result<bool, DecodeError<S>> {
+        name: &Spanned<Box<str>>,
+        value: &Value,
+        ctx: &mut Context,
+    ) -> Result<bool, DecodeError> {
         Rc::get_mut(self)
             .expect("no Rc clone yet")
             .insert_property(name, value, ctx)
     }
 }
 
-impl<S: ErrorSpan, T: DecodeScalar<S>> DecodeScalar<S> for Rc<T> {
-    fn type_check(type_name: &Option<Spanned<TypeName, S>>, ctx: &mut Context<S>) {
+impl<T: DecodeScalar> DecodeScalar for Rc<T> {
+    fn type_check(type_name: &Option<Spanned<TypeName>>, ctx: &mut Context) {
         T::type_check(type_name, ctx)
     }
-    fn raw_decode(
-        value: &Spanned<Literal, S>,
-        ctx: &mut Context<S>,
-    ) -> Result<Self, DecodeError<S>> {
+    fn raw_decode(value: &Spanned<Literal>, ctx: &mut Context) -> Result<Self, DecodeError> {
         DecodeScalar::raw_decode(value, ctx).map(Rc::new)
     }
 }
 
-impl<S: ErrorSpan, T: Decode<S>> DecodeChildren<S> for Vec<T> {
-    fn decode_children(
-        nodes: &[SpannedNode<S>],
-        ctx: &mut Context<S>,
-    ) -> Result<Self, DecodeError<S>> {
+impl<T: Decode> DecodeChildren for Vec<T> {
+    fn decode_children(nodes: &[SpannedNode], ctx: &mut Context) -> Result<Self, DecodeError> {
         let mut result = Vec::with_capacity(nodes.len());
         for node in nodes {
             match Decode::decode_node(node, ctx) {
@@ -167,14 +133,11 @@ impl<S: ErrorSpan, T: Decode<S>> DecodeChildren<S> for Vec<T> {
     }
 }
 
-impl<S: ErrorSpan, T: DecodeScalar<S>> DecodeScalar<S> for Option<T> {
-    fn type_check(type_name: &Option<Spanned<TypeName, S>>, ctx: &mut Context<S>) {
+impl<T: DecodeScalar> DecodeScalar for Option<T> {
+    fn type_check(type_name: &Option<Spanned<TypeName>>, ctx: &mut Context) {
         T::type_check(type_name, ctx)
     }
-    fn raw_decode(
-        value: &Spanned<Literal, S>,
-        ctx: &mut Context<S>,
-    ) -> Result<Self, DecodeError<S>> {
+    fn raw_decode(value: &Spanned<Literal>, ctx: &mut Context) -> Result<Self, DecodeError> {
         match &**value {
             Literal::Null => Ok(None),
             _ => DecodeScalar::raw_decode(value, ctx).map(Some),
@@ -182,18 +145,11 @@ impl<S: ErrorSpan, T: DecodeScalar<S>> DecodeScalar<S> for Option<T> {
     }
 }
 
-impl<T: DecodeScalar<S>, S, Q> DecodeScalar<S> for Spanned<T, Q>
-where
-    S: Span,
-    Q: DecodeSpan<S>,
-{
-    fn type_check(type_name: &Option<Spanned<TypeName, S>>, ctx: &mut Context<S>) {
+impl<T: DecodeScalar> DecodeScalar for Spanned<T> {
+    fn type_check(type_name: &Option<Spanned<TypeName>>, ctx: &mut Context) {
         T::type_check(type_name, ctx)
     }
-    fn raw_decode(
-        value: &Spanned<Literal, S>,
-        ctx: &mut Context<S>,
-    ) -> Result<Self, DecodeError<S>> {
+    fn raw_decode(value: &Spanned<Literal>, ctx: &mut Context) -> Result<Self, DecodeError> {
         let decoded = T::raw_decode(value, ctx)?;
         Ok(Spanned {
             span: DecodeSpan::decode_span(&value.span, ctx),

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -7,7 +7,7 @@ use crate::ast::{BuiltinType, Decimal, Integer, Literal, Radix, TypeName};
 use crate::decode::{Context, Kind};
 use crate::errors::{DecodeError, ExpectedType};
 use crate::span::Spanned;
-use crate::traits::{DecodeScalar, ErrorSpan};
+use crate::traits::DecodeScalar;
 
 macro_rules! impl_integer {
     ($typ: ident, $marker: ident) => {
@@ -23,11 +23,8 @@ macro_rules! impl_integer {
             }
         }
 
-        impl<S: ErrorSpan> DecodeScalar<S> for $typ {
-            fn raw_decode(
-                val: &Spanned<Literal, S>,
-                ctx: &mut Context<S>,
-            ) -> Result<$typ, DecodeError<S>> {
+        impl DecodeScalar for $typ {
+            fn raw_decode(val: &Spanned<Literal>, ctx: &mut Context) -> Result<$typ, DecodeError> {
                 match &**val {
                     Literal::Int(value) => match value.try_into() {
                         Ok(val) => Ok(val),
@@ -42,7 +39,7 @@ macro_rules! impl_integer {
                     }
                 }
             }
-            fn type_check(type_name: &Option<Spanned<TypeName, S>>, ctx: &mut Context<S>) {
+            fn type_check(type_name: &Option<Spanned<TypeName>>, ctx: &mut Context) {
                 if let Some(typ) = type_name {
                     if typ.as_builtin() != Some(&BuiltinType::$marker) {
                         ctx.emit_error(DecodeError::TypeName {
@@ -80,11 +77,8 @@ macro_rules! impl_float {
             }
         }
 
-        impl<S: ErrorSpan> DecodeScalar<S> for $typ {
-            fn raw_decode(
-                val: &Spanned<Literal, S>,
-                ctx: &mut Context<S>,
-            ) -> Result<$typ, DecodeError<S>> {
+        impl DecodeScalar for $typ {
+            fn raw_decode(val: &Spanned<Literal>, ctx: &mut Context) -> Result<$typ, DecodeError> {
                 match &**val {
                     Literal::Decimal(value) => match value.try_into() {
                         Ok(val) => Ok(val),
@@ -99,7 +93,7 @@ macro_rules! impl_float {
                     }
                 }
             }
-            fn type_check(type_name: &Option<Spanned<TypeName, S>>, ctx: &mut Context<S>) {
+            fn type_check(type_name: &Option<Spanned<TypeName>>, ctx: &mut Context) {
                 if let Some(typ) = type_name {
                     if typ.as_builtin() != Some(&BuiltinType::$marker) {
                         ctx.emit_error(DecodeError::TypeName {
@@ -118,11 +112,8 @@ macro_rules! impl_float {
 impl_float!(f32, F32);
 impl_float!(f64, F64);
 
-impl<S: ErrorSpan> DecodeScalar<S> for String {
-    fn raw_decode(
-        val: &Spanned<Literal, S>,
-        ctx: &mut Context<S>,
-    ) -> Result<String, DecodeError<S>> {
+impl DecodeScalar for String {
+    fn raw_decode(val: &Spanned<Literal>, ctx: &mut Context) -> Result<String, DecodeError> {
         match &**val {
             Literal::String(s) => Ok(s.clone().into()),
             _ => {
@@ -131,10 +122,10 @@ impl<S: ErrorSpan> DecodeScalar<S> for String {
             }
         }
     }
-    fn type_check(type_name: &Option<Spanned<TypeName, S>>, ctx: &mut Context<S>) {
+    fn type_check(type_name: &Option<Spanned<TypeName>>, ctx: &mut Context) {
         if let Some(typ) = type_name {
             ctx.emit_error(DecodeError::TypeName {
-                span: typ.span().clone(),
+                span: *typ.span(),
                 found: Some(typ.value.clone()),
                 expected: ExpectedType::no_type(),
                 rust_type: "String",
@@ -143,11 +134,8 @@ impl<S: ErrorSpan> DecodeScalar<S> for String {
     }
 }
 
-impl<S: ErrorSpan> DecodeScalar<S> for PathBuf {
-    fn raw_decode(
-        val: &Spanned<Literal, S>,
-        ctx: &mut Context<S>,
-    ) -> Result<PathBuf, DecodeError<S>> {
+impl DecodeScalar for PathBuf {
+    fn raw_decode(val: &Spanned<Literal>, ctx: &mut Context) -> Result<PathBuf, DecodeError> {
         match &**val {
             Literal::String(s) => Ok(String::from(s.clone()).into()),
             _ => {
@@ -156,10 +144,10 @@ impl<S: ErrorSpan> DecodeScalar<S> for PathBuf {
             }
         }
     }
-    fn type_check(type_name: &Option<Spanned<TypeName, S>>, ctx: &mut Context<S>) {
+    fn type_check(type_name: &Option<Spanned<TypeName>>, ctx: &mut Context) {
         if let Some(typ) = type_name {
             ctx.emit_error(DecodeError::TypeName {
-                span: typ.span().clone(),
+                span: *typ.span(),
                 found: Some(typ.value.clone()),
                 expected: ExpectedType::no_type(),
                 rust_type: "PathBuf",
@@ -168,11 +156,8 @@ impl<S: ErrorSpan> DecodeScalar<S> for PathBuf {
     }
 }
 
-impl<S: ErrorSpan> DecodeScalar<S> for Arc<Path> {
-    fn raw_decode(
-        val: &Spanned<Literal, S>,
-        ctx: &mut Context<S>,
-    ) -> Result<Arc<Path>, DecodeError<S>> {
+impl DecodeScalar for Arc<Path> {
+    fn raw_decode(val: &Spanned<Literal>, ctx: &mut Context) -> Result<Arc<Path>, DecodeError> {
         match &**val {
             Literal::String(s) => Ok(PathBuf::from(&(**s)[..]).into()),
             _ => {
@@ -181,10 +166,10 @@ impl<S: ErrorSpan> DecodeScalar<S> for Arc<Path> {
             }
         }
     }
-    fn type_check(type_name: &Option<Spanned<TypeName, S>>, ctx: &mut Context<S>) {
+    fn type_check(type_name: &Option<Spanned<TypeName>>, ctx: &mut Context) {
         if let Some(typ) = type_name {
             ctx.emit_error(DecodeError::TypeName {
-                span: typ.span().clone(),
+                span: *typ.span(),
                 found: Some(typ.value.clone()),
                 expected: ExpectedType::no_type(),
                 rust_type: "Arc<Path>",
@@ -193,11 +178,8 @@ impl<S: ErrorSpan> DecodeScalar<S> for Arc<Path> {
     }
 }
 
-impl<S: ErrorSpan> DecodeScalar<S> for Arc<str> {
-    fn raw_decode(
-        val: &Spanned<Literal, S>,
-        ctx: &mut Context<S>,
-    ) -> Result<Arc<str>, DecodeError<S>> {
+impl DecodeScalar for Arc<str> {
+    fn raw_decode(val: &Spanned<Literal>, ctx: &mut Context) -> Result<Arc<str>, DecodeError> {
         match &**val {
             Literal::String(s) => Ok(s.clone().into()),
             _ => {
@@ -206,10 +188,10 @@ impl<S: ErrorSpan> DecodeScalar<S> for Arc<str> {
             }
         }
     }
-    fn type_check(type_name: &Option<Spanned<TypeName, S>>, ctx: &mut Context<S>) {
+    fn type_check(type_name: &Option<Spanned<TypeName>>, ctx: &mut Context) {
         if let Some(typ) = type_name {
             ctx.emit_error(DecodeError::TypeName {
-                span: typ.span().clone(),
+                span: *typ.span(),
                 found: Some(typ.value.clone()),
                 expected: ExpectedType::no_type(),
                 rust_type: "Arc<str>",
@@ -218,8 +200,8 @@ impl<S: ErrorSpan> DecodeScalar<S> for Arc<str> {
     }
 }
 
-impl<S: ErrorSpan> DecodeScalar<S> for bool {
-    fn raw_decode(val: &Spanned<Literal, S>, ctx: &mut Context<S>) -> Result<bool, DecodeError<S>> {
+impl DecodeScalar for bool {
+    fn raw_decode(val: &Spanned<Literal>, ctx: &mut Context) -> Result<bool, DecodeError> {
         match &**val {
             Literal::Bool(value) => Ok(*value),
             _ => {
@@ -228,10 +210,10 @@ impl<S: ErrorSpan> DecodeScalar<S> for bool {
             }
         }
     }
-    fn type_check(type_name: &Option<Spanned<TypeName, S>>, ctx: &mut Context<S>) {
+    fn type_check(type_name: &Option<Spanned<TypeName>>, ctx: &mut Context) {
         if let Some(typ) = type_name {
             ctx.emit_error(DecodeError::TypeName {
-                span: typ.span().clone(),
+                span: *typ.span(),
                 found: Some(typ.value.clone()),
                 expected: ExpectedType::no_type(),
                 rust_type: "bool",

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -43,7 +43,7 @@ macro_rules! impl_integer {
                 if let Some(typ) = type_name {
                     if typ.as_builtin() != Some(&BuiltinType::$marker) {
                         ctx.emit_error(DecodeError::TypeName {
-                            span: typ.span().clone(),
+                            span: *typ.span(),
                             found: Some(typ.value.clone()),
                             expected: ExpectedType::optional(BuiltinType::$marker),
                             rust_type: stringify!($typ),
@@ -97,7 +97,7 @@ macro_rules! impl_float {
                 if let Some(typ) = type_name {
                     if typ.as_builtin() != Some(&BuiltinType::$marker) {
                         ctx.emit_error(DecodeError::TypeName {
-                            span: typ.span().clone(),
+                            span: *typ.span(),
                             found: Some(typ.value.clone()),
                             expected: ExpectedType::optional(BuiltinType::$marker),
                             rust_type: stringify!($typ),

--- a/src/convert_ast.rs
+++ b/src/convert_ast.rs
@@ -2,14 +2,10 @@ use crate::ast::{Literal, Node, SpannedNode, TypeName, Value};
 use crate::decode::Context;
 use crate::errors::DecodeError;
 use crate::span::Spanned;
-use crate::traits::{Decode, DecodeScalar, DecodeSpan, Span};
+use crate::traits::{Decode, DecodeScalar, DecodeSpan};
 
-impl<S, T> Decode<S> for Node<T>
-where
-    S: Span,
-    T: DecodeSpan<S>,
-{
-    fn decode_node(node: &SpannedNode<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>> {
+impl Decode for Node {
+    fn decode_node(node: &SpannedNode, ctx: &mut Context) -> Result<Self, DecodeError> {
         Ok(Node {
             type_name: node.type_name.as_ref().map(|n| n.clone_as(ctx)),
             node_name: node.node_name.clone_as(ctx),
@@ -45,12 +41,8 @@ where
     }
 }
 
-impl<S, T> Decode<S> for SpannedNode<T>
-where
-    S: Span,
-    T: DecodeSpan<S>,
-{
-    fn decode_node(node: &SpannedNode<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>> {
+impl Decode for SpannedNode {
+    fn decode_node(node: &SpannedNode, ctx: &mut Context) -> Result<Self, DecodeError> {
         Ok(Spanned {
             span: DecodeSpan::decode_span(&node.span, ctx),
             value: Decode::decode_node(node, ctx)?,
@@ -58,19 +50,12 @@ where
     }
 }
 
-impl<S, T> DecodeScalar<S> for Value<T>
-where
-    S: Span,
-    T: DecodeSpan<S>,
-{
-    fn type_check(_type_name: &Option<Spanned<TypeName, S>>, _ctx: &mut Context<S>) {}
-    fn raw_decode(
-        _value: &Spanned<Literal, S>,
-        _ctx: &mut Context<S>,
-    ) -> Result<Self, DecodeError<S>> {
+impl DecodeScalar for Value {
+    fn type_check(_type_name: &Option<Spanned<TypeName>>, _ctx: &mut Context) {}
+    fn raw_decode(_value: &Spanned<Literal>, _ctx: &mut Context) -> Result<Self, DecodeError> {
         panic!("called `raw_decode` directly on the `Value`");
     }
-    fn decode(value: &Value<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>> {
+    fn decode(value: &Value, ctx: &mut Context) -> Result<Self, DecodeError> {
         Ok(Value {
             type_name: value.type_name.as_ref().map(|n| n.clone_as(ctx)),
             literal: value.literal.clone_as(ctx),
@@ -78,15 +63,9 @@ where
     }
 }
 
-impl<S> DecodeScalar<S> for Literal
-where
-    S: Span,
-{
-    fn type_check(_type_name: &Option<Spanned<TypeName, S>>, _ctx: &mut Context<S>) {}
-    fn raw_decode(
-        value: &Spanned<Literal, S>,
-        _ctx: &mut Context<S>,
-    ) -> Result<Self, DecodeError<S>> {
+impl DecodeScalar for Literal {
+    fn type_check(_type_name: &Option<Spanned<TypeName>>, _ctx: &mut Context) {}
+    fn raw_decode(value: &Spanned<Literal>, _ctx: &mut Context) -> Result<Self, DecodeError> {
         Ok((**value).clone())
     }
 }

--- a/src/span.rs
+++ b/src/span.rs
@@ -1,21 +1,11 @@
-//! Knus can generate two types of span during parsing
-//!
-//! 1. [`Span`] which only tracks byte offset from the start of the source code
-//! 2. [`LineSpan`] which also track line numbers
-//!
-//! This distinction is important during parsing stage as [`Span`] is normally
-//! faster. And [`LineSpan`] is still faster than find out line/column number
-//! for each span separately, and is also more convenient if you need this
-//! information.
+//! Knus produces only a very simple span during parsing:
+//! [`Span`] which only tracks byte offset from the start of the source code
 //!
 //! On the other hand, on the decode stage you can convert your span types into
 //! more elaborate thing that includes file name or can refer to the defaults
 //! as a separate kind of span. See [`traits::DecodeSpan`].
-use std::fmt;
-use std::ops::Range;
-
 use crate::decode::Context;
-use crate::traits;
+use crate::traits::DecodeSpan;
 
 /// Reexport of [miette::SourceSpan] trait that we use for parsing
 pub use miette::SourceSpan as ErrorSpan;
@@ -23,14 +13,14 @@ pub use miette::SourceSpan as ErrorSpan;
 /// Wraps the structure to keep source code span, but also dereference to T
 #[derive(Copy, Clone, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
-pub struct Spanned<T, S> {
+pub struct Spanned<T> {
     #[cfg_attr(feature = "minicbor", n(0))]
-    pub(crate) span: S,
+    pub(crate) span: Span,
     #[cfg_attr(feature = "minicbor", n(1))]
     pub(crate) value: T,
 }
 
-/// Normal byte offset span
+/// A span based on byte offsets.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
 #[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
 pub struct Span(
@@ -38,62 +28,9 @@ pub struct Span(
     #[cfg_attr(feature = "minicbor", n(1))] pub usize,
 );
 
-/// Line and column position of the datum in the source code
-// TODO(tailhook) optimize Eq to check only offset
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-#[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
-pub struct LinePos {
-    /// Zero-based byte offset
-    #[cfg_attr(feature = "minicbor", n(0))]
-    pub offset: usize,
-    /// Zero-based line number
-    #[cfg_attr(feature = "minicbor", n(1))]
-    pub line: usize,
-    /// Zero-based column number
-    #[cfg_attr(feature = "minicbor", n(2))]
-    pub column: usize,
-}
-
-/// Span with line and column number
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, Default)]
-#[cfg_attr(feature = "minicbor", derive(minicbor::Encode, minicbor::Decode))]
-pub struct LineSpan(
-    #[cfg_attr(feature = "minicbor", n(0))] pub LinePos,
-    #[cfg_attr(feature = "minicbor", n(1))] pub LinePos,
-);
-
-#[allow(missing_debug_implementations)]
-mod sealed {
-
-    pub struct OffsetTracker {
-        pub(crate) offset: usize,
-    }
-
-    #[cfg(feature = "line-numbers")]
-    pub struct LineTracker {
-        pub(crate) offset: usize,
-        pub(crate) caret_return: bool,
-        pub(crate) line: usize,
-        pub(crate) column: usize,
-    }
-}
-
-impl Span {
-    /// Length of the span in bytes
-    pub fn length(&self) -> usize {
-        self.1.saturating_sub(self.0)
-    }
-}
-
 impl From<Span> for ErrorSpan {
     fn from(val: Span) -> Self {
         (val.0, val.1.saturating_sub(val.0)).into()
-    }
-}
-
-impl From<LineSpan> for ErrorSpan {
-    fn from(val: LineSpan) -> Self {
-        (val.0.offset, val.1.offset.saturating_sub(val.0.offset)).into()
     }
 }
 
@@ -101,7 +38,7 @@ impl chumsky::Span for Span {
     type Context = ();
     type Offset = usize;
     fn new(_context: (), range: std::ops::Range<usize>) -> Self {
-        Span(range.start(), range.end())
+        Span(range.start, range.end)
     }
     fn context(&self) {}
     fn start(&self) -> usize {
@@ -111,275 +48,202 @@ impl chumsky::Span for Span {
         self.1
     }
 }
-impl traits::sealed::SpanTracker for sealed::OffsetTracker {
-    type Span = Span;
-    fn next_span(&mut self, c: char) -> Span {
-        let start = self.offset;
-        self.offset += c.len_utf8();
-        Span(start, self.offset)
-    }
-}
 
-impl traits::sealed::Sealed for Span {
-    type Tracker = sealed::OffsetTracker;
-    fn at_start(&self, chars: usize) -> Self {
+impl Span {
+    /// Note assuming ascii, single-width, non-newline chars here
+    pub fn at_start(&self, chars: usize) -> Self {
         Span(self.0, self.0 + chars)
     }
 
-    fn at_end(&self) -> Self {
+    /// Return empty span at the end of this one.
+    pub fn at_end(&self) -> Self {
         Span(self.1, self.1)
     }
 
-    fn before_start(&self, chars: usize) -> Self {
+    /// Note assuming ascii, single-width, non-newline chars here
+    pub fn before_start(&self, chars: usize) -> Self {
         Span(self.0.saturating_sub(chars), self.0)
     }
 
-    fn length(&self) -> usize {
+    /// Length of the span
+    pub fn length(&self) -> usize {
         self.1.saturating_sub(self.0)
     }
 
-    fn stream(text: &str) -> traits::sealed::Stream<'_, Self, Self::Tracker>
+    /// Creates a stream of characters with spans from the given text.
+    pub fn stream(text: &str) -> Stream<'_, Self>
     where
         Self: chumsky::Span,
     {
+        let eoi = text.len();
         chumsky::Stream::from_iter(
-            Span(text.len(), text.len()),
-            traits::sealed::Map(text.chars(), sealed::OffsetTracker { offset: 0 }),
-        )
-    }
-}
-
-impl traits::Span for Span {}
-
-impl chumsky::Span for LineSpan {
-    type Context = ();
-    type Offset = LinePos;
-    fn new(_context: (), range: std::ops::Range<LinePos>) -> Self {
-        LineSpan(range.start, range.end)
-    }
-    fn context(&self) {}
-    fn start(&self) -> LinePos {
-        self.0
-    }
-    fn end(&self) -> LinePos {
-        self.1
-    }
-}
-
-#[cfg(feature = "line-numbers")]
-impl traits::sealed::SpanTracker for sealed::LineTracker {
-    type Span = LineSpan;
-    fn next_span(&mut self, c: char) -> LineSpan {
-        let offset = self.offset;
-        let line = self.line;
-        let column = self.column;
-        self.offset += c.len_utf8();
-        match c {
-            '\n' if self.caret_return => {}
-            '\r' | '\n' | '\x0C' | '\u{0085}' | '\u{2028}' | '\u{2029}' => {
-                self.line += 1;
-                self.column = 0;
-            }
-            '\t' => self.column += 8,
-            c => {
-                self.column += unicode_width::UnicodeWidthChar::width(c).unwrap_or(0);
-                // treat control chars as zero-length
-            }
-        }
-        self.caret_return = c == '\r';
-        LineSpan(
-            LinePos {
-                line,
-                column,
-                offset,
-            },
-            LinePos {
-                line: self.line,
-                column: self.column,
-                offset: self.offset,
-            },
-        )
-    }
-}
-
-#[cfg(feature = "line-numbers")]
-impl traits::sealed::Sealed for LineSpan {
-    type Tracker = sealed::LineTracker;
-    /// Note assuming ascii, single-width, non-newline chars here
-    fn at_start(&self, chars: usize) -> Self {
-        LineSpan(
-            self.0,
-            LinePos {
-                offset: self.0.offset + chars,
-                column: self.0.column + chars,
-                ..self.0
-            },
+            Span(eoi, eoi),
+            Map(text.chars(), OffsetTracker { offset: 0 }),
         )
     }
 
-    fn at_end(&self) -> Self {
-        LineSpan(self.1, self.1)
-    }
-
-    /// Note assuming ascii, single-width, non-newline chars here
-    fn before_start(&self, chars: usize) -> Self {
-        LineSpan(
-            LinePos {
-                offset: self.0.offset.saturating_sub(chars),
-                column: self.0.column.saturating_sub(chars),
-                ..self.0
-            },
-            self.0,
-        )
-    }
-
-    fn length(&self) -> usize {
-        self.1.offset.saturating_sub(self.0.offset)
-    }
-
-    fn stream(text: &str) -> traits::sealed::Stream<'_, Self, Self::Tracker>
-    where
-        Self: chumsky::Span,
-    {
-        let mut caret_return = false;
-        let mut line = 0;
-        let mut last_line = text;
-        let mut iter = text.chars();
-        while let Some(c) = iter.next() {
-            match c {
-                '\n' if caret_return => {}
-                '\r' | '\n' | '\x0C' | '\u{0085}' | '\u{2028}' | '\u{2029}' => {
-                    line += 1;
-                    last_line = iter.as_str();
-                }
-                _ => {}
-            }
-            caret_return = c == '\r';
-        }
-        let column = unicode_width::UnicodeWidthStr::width(last_line);
-        let eoi = LinePos {
-            line,
-            column,
-            offset: text.len(),
-        };
-        chumsky::Stream::from_iter(
-            LineSpan(eoi, eoi),
-            traits::sealed::Map(
-                text.chars(),
-                sealed::LineTracker {
-                    caret_return: false,
-                    offset: 0,
-                    line: 0,
-                    column: 0,
+    #[cfg(feature = "line-numbers")]
+    /// Converts the span's byte offsets to zero-based line/column pairs
+    pub fn to_line_column(&self, text: &str) -> ((usize, usize), (usize, usize)) {
+        let prefix = &text[..self.0];
+        let (start_line, start_column) = line_column_of_end(prefix);
+        let span_text = &text[self.0..self.1];
+        let (end_line, end_column) = line_column_of_end(span_text);
+        (
+            (start_line, start_column),
+            (
+                start_line + end_line,
+                if end_line == 0 {
+                    start_column + end_column
+                } else {
+                    end_column
                 },
             ),
         )
     }
 }
 
-#[cfg(feature = "line-numbers")]
-impl traits::Span for LineSpan {}
+fn line_column_of_end(text: &str) -> (usize, usize) {
+    let mut caret_return = false;
+    let mut line = 0;
+    let mut last_line = text;
+    let mut iter = text.chars();
+    while let Some(c) = iter.next() {
+        match c {
+            '\n' if caret_return => {}
+            '\r' | '\n' | '\x0C' | '\u{0085}' | '\u{2028}' | '\u{2029}' => {
+                line += 1;
+                last_line = iter.as_str();
+            }
+            _ => {}
+        }
+        caret_return = c == '\r';
+    }
+    let column = unicode_width::UnicodeWidthStr::width(last_line);
+    (line, column)
+}
 
-#[cfg(feature = "line-numbers")]
-impl traits::DecodeSpan<LineSpan> for Span {
-    fn decode_span(span: &LineSpan, _: &mut Context<LineSpan>) -> Self {
-        Span(span.0.offset, span.1.offset)
+/// Helper struct for computing spans
+#[derive(Debug)]
+pub struct OffsetTracker {
+    offset: usize,
+}
+
+impl OffsetTracker {
+    fn next_span(&mut self, c: char) -> Span {
+        let offset = self.offset;
+        self.offset += c.len_utf8();
+        Span(offset, self.offset)
     }
 }
 
-impl<T, S> Spanned<T, S> {
+/// A wrapper around an iterator that produces characters with spans.
+#[allow(missing_debug_implementations)]
+pub struct Map<I: Iterator<Item = char>>(pub(crate) I, pub(crate) OffsetTracker);
+
+/// Short-hand for chumsky's `Stream` type with our spans and chars.
+pub type Stream<'a, S> = chumsky::Stream<'a, char, S, Map<std::str::Chars<'a>>>;
+
+impl<I> Iterator for Map<I>
+where
+    I: Iterator<Item = char>,
+{
+    type Item = (char, Span);
+    fn next(&mut self) -> Option<(char, Span)> {
+        self.0.next().map(|c| (c, self.1.next_span(c)))
+    }
+}
+
+impl DecodeSpan for Span {
+    fn decode_span(span: &Span, _: &mut Context) -> Self {
+        *span
+    }
+}
+
+impl<T> Spanned<T> {
     /// Converts value but keeps the same span attached
-    pub fn map<R>(self, f: impl FnOnce(T) -> R) -> Spanned<R, S> {
+    pub fn map<R>(self, f: impl FnOnce(T) -> R) -> Spanned<R> {
         Spanned {
             span: self.span,
             value: f(self.value),
         }
     }
-    /// Converts span but keeps the same value attached
-    pub fn map_span<U>(self, f: impl FnOnce(S) -> U) -> Spanned<T, U> {
-        Spanned {
-            span: f(self.span),
-            value: self.value,
-        }
-    }
-    pub(crate) fn clone_as<U>(&self, ctx: &mut Context<S>) -> Spanned<T, U>
+    pub(crate) fn clone_as(&self, ctx: &mut Context) -> Spanned<T>
     where
-        U: traits::DecodeSpan<S>,
         T: Clone,
-        S: traits::ErrorSpan,
     {
         Spanned {
-            span: traits::DecodeSpan::decode_span(&self.span, ctx),
+            span: DecodeSpan::decode_span(&self.span, ctx),
             value: self.value.clone(),
         }
     }
 }
 
-impl<U: ?Sized, T: AsRef<U>, S> AsRef<U> for Spanned<T, S> {
+impl<U: ?Sized, T: AsRef<U>> AsRef<U> for Spanned<T> {
     fn as_ref(&self) -> &U {
         self.value.as_ref()
     }
 }
 
-impl<U: ?Sized, T: AsMut<U>, S> AsMut<U> for Spanned<T, S> {
+impl<U: ?Sized, T: AsMut<U>> AsMut<U> for Spanned<T> {
     fn as_mut(&mut self) -> &mut U {
         self.value.as_mut()
     }
 }
 
-impl<T, S> std::ops::Deref for Spanned<T, S> {
+impl<T> std::ops::Deref for Spanned<T> {
     type Target = T;
     fn deref(&self) -> &T {
         &self.value
     }
 }
 
-impl<T, S> std::ops::DerefMut for Spanned<T, S> {
+impl<T> std::ops::DerefMut for Spanned<T> {
     fn deref_mut(&mut self) -> &mut T {
         &mut self.value
     }
 }
 
-impl<T, S> std::borrow::Borrow<T> for Spanned<T, S> {
+impl<T> std::borrow::Borrow<T> for Spanned<T> {
     fn borrow(&self) -> &T {
         self.value.borrow()
     }
 }
 
-impl<T: ?Sized, S> std::borrow::Borrow<T> for Spanned<Box<T>, S> {
+impl<T: ?Sized> std::borrow::Borrow<T> for Spanned<Box<T>> {
     fn borrow(&self) -> &T {
         self.value.borrow()
     }
 }
 
-impl<T, S> Spanned<T, S> {
+impl<T> Spanned<T> {
     /// Returns the span of the value
-    pub fn span(&self) -> &S {
+    pub fn span(&self) -> &Span {
         &self.span
     }
 }
 
-impl<S, T: PartialEq<T>> PartialEq for Spanned<T, S> {
-    fn eq(&self, other: &Spanned<T, S>) -> bool {
+impl<T: PartialEq<T>> PartialEq for Spanned<T> {
+    fn eq(&self, other: &Spanned<T>) -> bool {
         self.value == other.value
     }
 }
 
-impl<S, T: PartialOrd<T>> PartialOrd for Spanned<T, S> {
-    fn partial_cmp(&self, other: &Spanned<T, S>) -> Option<std::cmp::Ordering> {
+impl<T: PartialOrd<T>> PartialOrd for Spanned<T> {
+    fn partial_cmp(&self, other: &Spanned<T>) -> Option<std::cmp::Ordering> {
         self.value.partial_cmp(&other.value)
     }
 }
 
-impl<S, T: Ord> Ord for Spanned<T, S> {
-    fn cmp(&self, other: &Spanned<T, S>) -> std::cmp::Ordering {
+impl<T: Ord> Ord for Spanned<T> {
+    fn cmp(&self, other: &Spanned<T>) -> std::cmp::Ordering {
         self.value.cmp(&other.value)
     }
 }
 
-impl<S, T: Eq> Eq for Spanned<T, S> {}
+impl<T: Eq> Eq for Spanned<T> {}
 
-impl<S, T: std::hash::Hash> std::hash::Hash for Spanned<T, S> {
+impl<T: std::hash::Hash> std::hash::Hash for Spanned<T> {
     fn hash<H>(&self, state: &mut H)
     where
         H: std::hash::Hasher,
@@ -388,17 +252,42 @@ impl<S, T: std::hash::Hash> std::hash::Hash for Spanned<T, S> {
     }
 }
 
-impl fmt::Display for Span {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)?;
-        "..".fmt(f)?;
-        self.1.fmt(f)?;
-        Ok(())
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_line_column() {
+        let text = "Hello\nWorld!\nThis is a test.\n";
+        let span = Span(6, 12); // "World!"
+        let ((start_line, start_col), (end_line, end_col)) = span.to_line_column(text);
+        assert_eq!((start_line, start_col), (1, 0));
+        assert_eq!((end_line, end_col), (1, 6));
+        let span2 = Span(0, 5); // "Hello"
+        let ((s_line, s_col), (e_line, e_col)) = span2.to_line_column(text);
+        assert_eq!((s_line, s_col), (0, 0));
+        assert_eq!((e_line, e_col), (0, 5));
+        let span3 = Span(17, 25); // " is a te"
+        let ((s_line3, s_col3), (e_line3, e_col3)) = span3.to_line_column(text);
+        assert_eq!((s_line3, s_col3), (2, 4));
+        assert_eq!((e_line3, e_col3), (2, 12));
     }
-}
 
-impl From<Range<usize>> for Span {
-    fn from(r: Range<usize>) -> Span {
-        Span(r.start, r.end)
+    #[test]
+    fn test_line_column_carriage_return() {
+        let text = "Line1\rLine2\r\nLine3\nLine4";
+        let span = Span(6, 11); // "Line2"
+        let ((start_line, start_col), (end_line, end_col)) = span.to_line_column(text);
+        assert_eq!((start_line, start_col), (1, 0));
+        assert_eq!((end_line, end_col), (1, 5));
+    }
+
+    #[test]
+    fn test_line_column_multi_byte() {
+        let text = "Hellö\n, Flöße";
+        let span = Span(9, 16); // "Flöße"
+        println!("Span: {}", &text[9..16]);
+        let ((start_line, start_col), (end_line, end_col)) = span.to_line_column(text);
+        assert_eq!((start_line, start_col), (1, 2));
+        assert_eq!((end_line, end_col), (1, 7));
     }
 }

--- a/src/span.rs
+++ b/src/span.rs
@@ -50,7 +50,7 @@ impl chumsky::Span for Span {
 }
 
 impl Span {
-    /// Note assuming ascii, single-width, non-newline chars here
+    /// Return a span of the given length at the start of this one.
     pub fn at_start(&self, chars: usize) -> Self {
         Span(self.0, self.0 + chars)
     }
@@ -60,7 +60,7 @@ impl Span {
         Span(self.1, self.1)
     }
 
-    /// Note assuming ascii, single-width, non-newline chars here
+    /// Return a span of the given length before the start of this one.
     pub fn before_start(&self, chars: usize) -> Self {
         Span(self.0.saturating_sub(chars), self.0)
     }
@@ -125,7 +125,7 @@ fn line_column_of_end(text: &str) -> (usize, usize) {
 
 /// Helper struct for computing spans
 #[derive(Debug)]
-pub struct OffsetTracker {
+struct OffsetTracker {
     offset: usize,
 }
 
@@ -139,10 +139,10 @@ impl OffsetTracker {
 
 /// A wrapper around an iterator that produces characters with spans.
 #[allow(missing_debug_implementations)]
-pub struct Map<I: Iterator<Item = char>>(pub(crate) I, pub(crate) OffsetTracker);
+pub struct Map<I: Iterator<Item = char>>(I, OffsetTracker);
 
 /// Short-hand for chumsky's `Stream` type with our spans and chars.
-pub type Stream<'a, S> = chumsky::Stream<'a, char, S, Map<std::str::Chars<'a>>>;
+type Stream<'a, S> = chumsky::Stream<'a, char, S, Map<std::str::Chars<'a>>>;
 
 impl<I> Iterator for Map<I>
 where

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -4,26 +4,21 @@
 //! [`Decode`](derive@crate::Decode)` and
 //! [`DecodeScalar`](derive@crate::DecodeScalar) for a
 //! documentation of the derives to implement these traits.
-use std::fmt;
-
 use crate::ast::{Literal, SpannedNode, TypeName, Value};
 use crate::decode::Context;
 use crate::errors::DecodeError;
-use crate::span::Spanned;
+use crate::span::{Span, Spanned};
 
 /// Trait to decode KDL node from the AST
-pub trait Decode<S: ErrorSpan>: Sized {
+pub trait Decode: Sized {
     /// Decodes the node from the ast
-    fn decode_node(node: &SpannedNode<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>>;
+    fn decode_node(node: &SpannedNode, ctx: &mut Context) -> Result<Self, DecodeError>;
 }
 
 /// Trait to decode children of the KDL node, mostly used for root document
-pub trait DecodeChildren<S: ErrorSpan>: Sized {
+pub trait DecodeChildren: Sized {
     /// Decodes from a list of chidren ASTs
-    fn decode_children(
-        nodes: &[SpannedNode<S>],
-        ctx: &mut Context<S>,
-    ) -> Result<Self, DecodeError<S>>;
+    fn decode_children(nodes: &[SpannedNode], ctx: &mut Context) -> Result<Self, DecodeError>;
 }
 
 /// The trait is implemented for structures that can be used as part of other
@@ -33,17 +28,13 @@ pub trait DecodeChildren<S: ErrorSpan>: Sized {
 /// this trait. It is automatically implemented by `#[derive(knus::Decode)]`
 /// by structures that have only optional properties and children (no
 /// arguments).
-pub trait DecodePartial<S: ErrorSpan>: Sized {
+pub trait DecodePartial: Sized {
     /// The method is called when unknown child is encountered by parent
     /// structure
     ///
     /// Returns `Ok(true)` if the child is "consumed" (i.e. stored in this
     /// structure).
-    fn insert_child(
-        &mut self,
-        node: &SpannedNode<S>,
-        ctx: &mut Context<S>,
-    ) -> Result<bool, DecodeError<S>>;
+    fn insert_child(&mut self, node: &SpannedNode, ctx: &mut Context) -> Result<bool, DecodeError>;
     /// The method is called when unknown property is encountered by parent
     /// structure
     ///
@@ -51,105 +42,42 @@ pub trait DecodePartial<S: ErrorSpan>: Sized {
     /// structure).
     fn insert_property(
         &mut self,
-        name: &Spanned<Box<str>, S>,
-        value: &Value<S>,
-        ctx: &mut Context<S>,
-    ) -> Result<bool, DecodeError<S>>;
+        name: &Spanned<Box<str>>,
+        value: &Value,
+        ctx: &mut Context,
+    ) -> Result<bool, DecodeError>;
 }
 
 /// The trait that decodes scalar value and checks its type
-pub trait DecodeScalar<S: ErrorSpan>: Sized {
+pub trait DecodeScalar: Sized {
     /// Typecheck the value
     ///
     /// This method can only emit errors to the context in type mismatch case.
     /// Errors emitted to the context are considered fatal once the whole data
     /// is processed but non fatal when encountered. So even if there is a type
     /// in type name we can proceed and try parsing actual value.
-    fn type_check(type_name: &Option<Spanned<TypeName, S>>, ctx: &mut Context<S>);
+    fn type_check(type_name: &Option<Spanned<TypeName>>, ctx: &mut Context);
     /// Decode value without typecheck
     ///
     /// This can be used by wrappers to parse some know value but use a
     /// different typename (kinda emulated subclassing)
-    fn raw_decode(
-        value: &Spanned<Literal, S>,
-        ctx: &mut Context<S>,
-    ) -> Result<Self, DecodeError<S>>;
+    fn raw_decode(value: &Spanned<Literal>, ctx: &mut Context) -> Result<Self, DecodeError>;
     /// Decode the value and typecheck
     ///
     /// This should not be overriden and uses `type_check` in combination with
     /// `raw_decode`.
-    fn decode(value: &Value<S>, ctx: &mut Context<S>) -> Result<Self, DecodeError<S>> {
+    fn decode(value: &Value, ctx: &mut Context) -> Result<Self, DecodeError> {
         Self::type_check(&value.type_name, ctx);
         Self::raw_decode(&value.literal, ctx)
     }
 }
 
 /// The trait that decodes span into the final structure
-pub trait DecodeSpan<S: ErrorSpan>: Sized {
+pub trait DecodeSpan: Sized {
     /// Decode span
     ///
     /// This method can use some extra data (say file name) from the context.
     /// Although, by default context is empty and end users are expected to use
     /// [`parse_with_context`](crate::parse_with_context) to add some values.
-    fn decode_span(span: &S, ctx: &mut Context<S>) -> Self;
-}
-
-impl<T: ErrorSpan> DecodeSpan<T> for T {
-    fn decode_span(span: &T, _: &mut Context<T>) -> Self {
-        span.clone()
-    }
-}
-
-/// Span must implement this trait to be used in the error messages
-///
-/// Custom span types can be used for this unlike for [`Span`]
-pub trait ErrorSpan: Into<miette::SourceSpan> + Clone + fmt::Debug + Send + Sync + 'static {}
-impl<T> ErrorSpan for T
-where
-    T: Into<miette::SourceSpan>,
-    T: Clone + fmt::Debug + Send + Sync + 'static,
-{
-}
-
-/// Span trait used for parsing source code
-///
-/// It's sealed because needs some tight interoperation with the parser. Use
-/// [`DecodeSpan`] to convert spans whenever needed.
-pub trait Span: sealed::Sealed + chumsky::Span + ErrorSpan {}
-
-#[allow(missing_debug_implementations)]
-pub(crate) mod sealed {
-    pub type Stream<'a, S, T> = chumsky::Stream<'a, char, S, Map<std::str::Chars<'a>, T>>;
-
-    pub struct Map<I, F>(pub(crate) I, pub(crate) F);
-
-    pub trait SpanTracker {
-        type Span;
-        fn next_span(&mut self, c: char) -> Self::Span;
-    }
-
-    impl<I, T> Iterator for Map<I, T>
-    where
-        I: Iterator<Item = char>,
-        T: SpanTracker,
-    {
-        type Item = (char, T::Span);
-        fn next(&mut self) -> Option<(char, T::Span)> {
-            self.0.next().map(|c| (c, self.1.next_span(c)))
-        }
-    }
-
-    pub trait Sealed {
-        type Tracker: SpanTracker<Span = Self>;
-        /// Note assuming ascii, single-width, non-newline chars here
-        fn at_start(&self, chars: usize) -> Self;
-        fn at_end(&self) -> Self;
-        /// Note assuming ascii, single-width, non-newline chars here
-        fn before_start(&self, chars: usize) -> Self;
-        fn length(&self) -> usize;
-
-        fn stream(s: &str) -> Stream<'_, Self, Self::Tracker>
-        where
-            Self: chumsky::Span;
-    }
+    fn decode_span(span: &Span, ctx: &mut Context) -> Self;
 }


### PR DESCRIPTION
For use by the library user, this span type can still be transformed to a different span type.

In #33 I wrote that it might be possible to still have the parser be generic over the span with chumsky 0.10, but after thinking about it more, I couldn't find a reasonable way to do it, actually. The reason is that chumsky 0.10 now computes spans internally, so the only way to do it would be to transform the spans individually, which is much more expensive than what was possible with chumsky 0.9 where we could keep track of column number and line number and compute the `LineSpan` on-the-fly. I don't see a way to do this on-the-fly computation in chumsky 0.10.