### PR TITLE
Migrate from chumsky 0.9.3 to chumsky 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-chumsky = { version="0.9.3", default-features=false }
+# Using latest commit until chumsky 0.13.0 is released
+chumsky = { git = "https://github.com/zesterer/chumsky.git", rev = "b81c34c", default-features=false }
 knus-derive = { path="./derive", version= "3.3.1", optional=true }
 base64 = { version="0.22.1", optional=true }
 unicode-width = { version="0.2.0", optional=true }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -6,6 +6,10 @@ use std::borrow::Cow;
 use std::collections::BTreeSet;
 use std::fmt::{self, Write};
 
+use chumsky::DefaultExpected;
+use chumsky::label::LabelError;
+use chumsky::span::SimpleSpan;
+use chumsky::util::Maybe;
 use miette::{Diagnostic, NamedSource};
 use thiserror::Error;
 
@@ -222,6 +226,17 @@ impl From<&'static str> for TokenFormat {
     }
 }
 
+impl TryFrom<DefaultExpected<'_, char>> for TokenFormat {
+    type Error = ();
+    fn try_from(e: DefaultExpected<'_, char>) -> Result<TokenFormat, ()> {
+        match e {
+            DefaultExpected::Token(c) => Ok(TokenFormat::Char(*c)),
+            DefaultExpected::EndOfInput => Ok(TokenFormat::Eoi),
+            _ => Err(()),
+        }
+    }
+}
+
 impl fmt::Display for TokenFormat {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use TokenFormat::*;
@@ -350,30 +365,41 @@ impl ParseError {
     }
 }
 
-impl chumsky::Error<char> for ParseError {
-    type Span = Span;
-    type Label = &'static str;
-    fn expected_input_found<Iter>(span: Self::Span, expected: Iter, found: Option<char>) -> Self
-    where
-        Iter: IntoIterator<Item = Option<char>>,
-    {
+impl<'src> LabelError<'src, &'src str, DefaultExpected<'src, char>> for ParseError {
+    fn expected_found<E: IntoIterator<Item = DefaultExpected<'src, char>>>(
+        expected: E,
+        found: Option<Maybe<char, &'src char>>,
+        span: SimpleSpan,
+    ) -> Self {
         ParseError::Unexpected {
             label: None,
-            span,
-            found: found.into(),
-            expected: expected.into_iter().map(Into::into).collect(),
+            span: span.into(),
+            found: found.map(|c| *c).into(),
+            expected: expected
+                .into_iter()
+                .filter_map(|e| e.try_into().ok())
+                .collect(),
         }
     }
-    fn with_label(mut self, new_label: Self::Label) -> Self {
+    fn label_with(&mut self, new_label: DefaultExpected<'src, char>) {
         use ParseError::*;
+        let new_label = match new_label {
+            DefaultExpected::EndOfInput => "end of input",
+            DefaultExpected::Token(_) => "token",
+            DefaultExpected::Any => "any",
+            DefaultExpected::SomethingElse => "something else",
+            _ => "other",
+        };
         match self {
-            Unexpected { ref mut label, .. } => *label = Some(new_label),
-            Unclosed { ref mut label, .. } => *label = new_label,
-            Message { ref mut label, .. } => *label = Some(new_label),
-            MessageWithHelp { ref mut label, .. } => *label = Some(new_label),
+            Unexpected { label, .. } => *label = Some(new_label),
+            Unclosed { label, .. } => *label = new_label,
+            Message { label, .. } => *label = Some(new_label),
+            MessageWithHelp { label, .. } => *label = Some(new_label),
         }
-        self
     }
+}
+
+impl<'src> chumsky::error::Error<'src, &'src str> for ParseError {
     fn merge(mut self, other: Self) -> Self {
         use ParseError::*;
         match (&mut self, other) {
@@ -383,25 +409,10 @@ impl chumsky::Error<char> for ParseError {
                 dest.extend(expected);
                 self
             }
+            (MessageWithHelp { .. }, _) => self,
+            (_, other @ MessageWithHelp { .. }) => other,
             (Message { .. }, _) => self,
             (_, other @ Message { .. }) => other,
-            (_, other) => todo!("{} -> {}", self, other),
-        }
-    }
-    fn unclosed_delimiter(
-        unclosed_span: Self::Span,
-        unclosed: char,
-        span: Self::Span,
-        expected: char,
-        found: Option<char>,
-    ) -> Self {
-        ParseError::Unclosed {
-            label: "delimited",
-            opened_at: unclosed_span,
-            opened: unclosed.into(),
-            expected_at: span,
-            expected: expected.into(),
-            found: found.into(),
         }
     }
 }

--- a/src/span.rs
+++ b/src/span.rs
@@ -7,6 +7,7 @@
 use crate::decode::Context;
 use crate::traits::DecodeSpan;
 
+use chumsky::span::SimpleSpan;
 /// Reexport of [miette::SourceSpan] trait that we use for parsing
 pub use miette::SourceSpan as ErrorSpan;
 
@@ -34,7 +35,7 @@ impl From<Span> for ErrorSpan {
     }
 }
 
-impl chumsky::Span for Span {
+impl chumsky::span::Span for Span {
     type Context = ();
     type Offset = usize;
     fn new(_context: (), range: std::ops::Range<usize>) -> Self {
@@ -46,6 +47,12 @@ impl chumsky::Span for Span {
     }
     fn end(&self) -> usize {
         self.1
+    }
+}
+
+impl From<SimpleSpan> for Span {
+    fn from(value: SimpleSpan) -> Self {
+        Span(value.start, value.end)
     }
 }
 
@@ -68,18 +75,6 @@ impl Span {
     /// Length of the span
     pub fn length(&self) -> usize {
         self.1.saturating_sub(self.0)
-    }
-
-    /// Creates a stream of characters with spans from the given text.
-    pub fn stream(text: &str) -> Stream<'_, Self>
-    where
-        Self: chumsky::Span,
-    {
-        let eoi = text.len();
-        chumsky::Stream::from_iter(
-            Span(eoi, eoi),
-            Map(text.chars(), OffsetTracker { offset: 0 }),
-        )
     }
 
     #[cfg(feature = "line-numbers")]
@@ -121,37 +116,6 @@ fn line_column_of_end(text: &str) -> (usize, usize) {
     }
     let column = unicode_width::UnicodeWidthStr::width(last_line);
     (line, column)
-}
-
-/// Helper struct for computing spans
-#[derive(Debug)]
-struct OffsetTracker {
-    offset: usize,
-}
-
-impl OffsetTracker {
-    fn next_span(&mut self, c: char) -> Span {
-        let offset = self.offset;
-        self.offset += c.len_utf8();
-        Span(offset, self.offset)
-    }
-}
-
-/// A wrapper around an iterator that produces characters with spans.
-#[allow(missing_debug_implementations)]
-pub struct Map<I: Iterator<Item = char>>(I, OffsetTracker);
-
-/// Short-hand for chumsky's `Stream` type with our spans and chars.
-type Stream<'a, S> = chumsky::Stream<'a, char, S, Map<std::str::Chars<'a>>>;
-
-impl<I> Iterator for Map<I>
-where
-    I: Iterator<Item = char>,
-{
-    type Item = (char, Span);
-    fn next(&mut self) -> Option<(char, Span)> {
-        self.0.next().map(|c| (c, self.1.next_span(c)))
-    }
 }
 
 impl DecodeSpan for Span {

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -5,13 +5,13 @@ use crate::ast::Document;
 use crate::decode::Context;
 use crate::errors::Error;
 use crate::grammar;
-use crate::span::Span;
 use crate::traits::DecodeChildren;
 
 /// Parse KDL text and return AST
 pub fn parse_ast(file_name: impl AsRef<str>, text: &str) -> Result<Document, Error> {
     grammar::document()
-        .parse(Span::stream(text))
+        .parse(text)
+        .into_result()
         .map_err(|errors| Error {
             source_code: NamedSource::new(file_name, text.to_string()),
             errors: errors.into_iter().map(Into::into).collect(),


### PR DESCRIPTION
Chumsky 0.13 hasn't been released yet, unfortunately, so we'll either have to wait for that or use chumsky from git.